### PR TITLE
data: add experiment results for Milestone 6-A, 6-AB, 6-AC, 6-D

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,190 +17,134 @@
 
 ---
 
-## Phase 1: Core Infrastructure
+## Phase 1: Core Infrastructure (COMPLETED)
 
 *Establishes the ACM MCP server skeleton and experience store.*
 
-### Deliverables
+- [x] MCP server project setup (TypeScript, `@modelcontextprotocol/sdk`)
+- [x] SQLite experience store (schema per SPECIFICATION.md Section 4)
+- [x] Experience entry CRUD operations
+- [x] Configuration system (mode, top_k, thresholds)
+- [x] Unit tests for store operations (33 tests)
 
-- [ ] MCP server project setup (TypeScript, `@modelcontextprotocol/sdk`)
-- [ ] SQLite experience store (schema per SPECIFICATION.md Section 4)
-- [ ] Experience entry CRUD operations
-- [ ] Configuration system (mode, top_k, thresholds)
-- [ ] Unit tests for store operations
-
-### Completion Criteria
-
-- MCP server starts and responds to health check
-- Experience entries can be created, read, queried
-- All unit tests pass
-- Configuration toggles work (disabled/success_only/failure_only/full)
-
-### Corresponds to
-
-- SPECIFICATION.md Section 4 (Experience Store)
-- SPECIFICATION.md Section 5.1 (Configuration)
+**Completed**: PR #6, merge commit 5aefcad
 
 ---
 
-## Phase 2: Signal Collection
+## Phase 2: Signal Collection (COMPLETED)
 
 *Implements hooks that capture implicit feedback signals.*
 
-### Deliverables
+- [x] PostToolUseFailure hook — interrupt detection (Level 1)
+- [x] UserPromptSubmit hook — post-interrupt dialogue capture + corrective instruction detection (Level 1, 3)
+- [x] PostToolUse hook — successful tool completion tracking (Level 4)
+- [x] Stop hook — normal completion recording
+- [x] Signal aggregation per session
+- [x] Unit tests (64 tests)
 
-- [ ] PostToolUseFailure hook — interrupt detection (Level 1)
-- [ ] UserPromptSubmit hook — post-interrupt dialogue capture + corrective instruction detection (Level 1, 3)
-- [ ] PostToolUse hook — successful tool completion tracking (Level 4)
-- [ ] Stop hook — normal completion recording
-- [ ] Signal aggregation per session
-- [ ] Unit tests for each signal type
-
-### Completion Criteria
-
-- Interrupt events correctly detected and recorded
-- Post-interrupt N=3–5 turns captured
-- Corrective instruction patterns detected
-- Session signal state correctly aggregated
-- All unit tests pass
-
-### Corresponds to
-
-- SPECIFICATION.md Section 3 (Hook Implementations)
-- Paper Section 4 (Signal Taxonomy) — Levels 1, 3, 4
+**Completed**: PR #12
 
 ---
 
-## Phase 3: Experience Generation
+## Phase 3: Experience Generation (COMPLETED)
 
 *Converts collected signals into scored experience entries.*
 
-### Deliverables
+- [x] SessionEnd hook — experience entry generation
+- [x] Signal strength scoring (per SPECIFICATION.md Section 2.2)
+- [x] Retrieval key extraction (keyword extraction from session content)
+- [x] Promotion threshold filtering
+- [x] Success/failure entry generation logic
+- [x] Unit tests (51 tests)
 
-- [ ] SessionEnd hook — experience entry generation
-- [ ] Signal strength scoring (per SPECIFICATION.md Section 2.2)
-- [ ] Retrieval key extraction (keyword extraction from session content)
-- [ ] Promotion threshold filtering
-- [ ] Success/failure entry generation logic
-- [ ] Unit tests for scoring and generation
-
-### Completion Criteria
-
-- Sessions with interrupts generate failure entries with correct signal strength
-- Sessions with clean completion generate success entries
-- Sessions with mixed signals generate both entry types
-- Entries below promotion threshold are discarded
-- All unit tests pass
-
-### Corresponds to
-
-- SPECIFICATION.md Section 2 (Experience Entry Structure)
-- Paper Section 3.4 (Experience Scoring and Promotion)
+**Completed**: PR #18
 
 ---
 
-## Phase 4: Retrieval and Injection
+## Phase 4: Retrieval and Injection (COMPLETED)
 
 *Implements semantic retrieval and context injection at session start.*
 
-### Deliverables
+- [x] Embedding generation for retrieval keys (all-MiniLM-L6-v2, 384-dim)
+- [x] Cosine similarity search over experience DB
+- [x] SessionStart hook — retrieve and inject relevant experiences
+- [x] Injection text formatting (compact, <500 tokens for top-5)
+- [x] Integration tests: full write→retrieve cycle (50 tests)
 
-- [ ] Embedding generation for retrieval keys (local model)
-- [ ] Cosine similarity search over experience DB
-- [ ] SessionStart hook — retrieve and inject relevant experiences
-- [ ] Injection text formatting (compact, <500 tokens for top-5)
-- [ ] Integration tests: full write→retrieve cycle
-
-### Completion Criteria
-
-- Relevant entries retrieved by semantic similarity
-- Injection text correctly formatted and under token budget
-- Full cycle works: signal capture → entry generation → retrieval → injection
-- Integration tests pass
-
-### Corresponds to
-
-- SPECIFICATION.md Section 3.1 (SessionStart Hook)
-- SPECIFICATION.md Section 4.3 (Retrieval)
-- Paper Section 3.3 (Retrieval and Injection)
+**Completed**: PR #26
 
 ---
 
-## Phase 5: Experimental Task Suite
+## Phase 5: Experimental Task Suite (COMPLETED)
 
 *Creates the task definitions and evaluation harness for Paper Section 5.4.*
 
-### Deliverables
+- [x] Task A: Multi-file bug fix (seeded bug + test suite)
+- [x] Task B: Feature addition (specification + functional tests)
+- [x] Task C: Refactoring (codebase + linting rules + consistency checks)
+- [x] Evaluation harness: automated metric collection
+- [x] Experiment runner: hook-free execution via `claude --print`
 
-- [ ] Task A: Multi-file bug fix — seeded bug in test codebase + test suite
-- [ ] Task B: Feature addition — specification document + functional tests
-- [ ] Task C: Refactoring — codebase + linting rules + consistency checks
-- [ ] Evaluation harness: automated metric collection
-- [ ] Experiment runner: execute conditions × context sizes × repetitions
-
-### Completion Criteria
-
-- Each task has a reproducible setup (codebase, seed, tests)
-- Evaluation metrics (Section 5.5) are automatically collected
-- Experiment runner can execute all conditions defined in Section 5.2
-
-### Corresponds to
-
-- SPECIFICATION.md Section 6 (Task Suite)
-- Paper Section 5.4 (Task Suite)
-- Paper Section 5.5 (Evaluation Metrics)
+**Completed**: PR #36 (task suite), PR #44 (hook integration), PR #48 (hook-free runner)
 
 ---
 
 ## Phase 6: Experimental Execution and Analysis
 
-*Run experiments and analyze results for RQ1–RQ5.*
+*Run experiments and analyze results. 3本柱アプローチで ASE 2026 (3/26) に向けた証拠を構築する。*
 
-### Milestone 6-A: Minimum Viable Validation（最初に実行）
+### Milestone 6-A: Automated Pipeline Validation (COMPLETED)
 
-**目的**: 最小セットで ACM の有効性を確認する。
+**目的**: 自動実験パイプラインで ACM injection mechanism を検証する。
 
-- 条件: Control vs ACM-SF（2条件のみ）
-- タスク: Task A のみ
-- コンテキストサイズ: Full (128k) のみ
-- セッション数: 5回 × 2条件 = 10セッション
+実施済み結果:
 
-完了条件: RQ1 の仮説（ACM-SF が Control より高い task completion rate /
-低い interrupt count）について傾向が確認できること。
+| Task | Control | ACM-SF | 備考 |
+|------|---------|--------|------|
+| Task A | 1.000 | 1.000 | 天井効果 |
+| Task B | 1.000 | 1.000 | 天井効果 |
+| Task C（初回） | 0.912 | 0.863 | ACM 逆方向 |
+| Task C（改善後） | 0.938 | 0.950 | +1.25%、有意差なし |
 
-### Milestone 6-D: Task D — Dungeon Generator（Ceiling Effect 回避）
+知見:
+- Task A/B は天井効果により ACM 効果を測定不可
+- 経験エントリの品質改善（actionable outcome）で方向は正に転じた
+- Task C は baseline が高く改善余地が限定的
 
-**背景**: Milestone 6-A で Task A/B が天井効果（completion_rate = 1.000）、Task C は ACM-SF が Control を下回る結果。
-より難易度の高いアルゴリズムタスクで再検証する。
+**Completed**: PR #54 (experience quality improvement), PR #58 (re-experiment results)
 
-- 条件: Control vs ACM-SF（2条件）
-- タスク: Task D（2D Dungeon Generator）のみ
-- コンテキストサイズ: Full (128k) のみ
-- セッション数: 5回 × 2条件 = 10セッション
+### Milestone 6-D: Task D — Harder Task for Ceiling Effect Mitigation
 
-完了条件: completion_rate に条件間差が観察される（天井効果なし）。
+**目的**: より難易度の高いタスクで天井効果を回避し、ACM injection の効果を測定する。
 
-**注意**: これは探索的な追試であり、Task D で ACM 効果が測定できることを保証するものではない。
-null result（差が出ない）も「アルゴリズム実装タスクでは ACM の効果が限定的」という知見として有意義。
+- [ ] Task D 実装（2D Dungeon Generator or 代替タスク）
+- [ ] reset.sh / vitest 採点環境の整備
+- [ ] Control × 5 + ACM-SF × 5 = 10セッション実行
+- [ ] 結果分析・記録
 
-### Milestone 6-B: Full Experimental Set（Milestone 6-A 結果を見て判断）
+完了条件: completion_rate にばらつきがあり（天井効果なし）、条件間差が観察可能。
+null result も「タスク難易度と ACM 効果の関係」の知見として有意義。
 
-論文 Section 5.2 の全条件（225回）。Milestone 6-A の結果を見てやまとさんが実施を判断する。
+### Milestone 6-E: PTY Signal Case Study（定性デモンストレーション）
 
-### Deliverables
+**目的**: ACM の差別化ポイントである PTY シグナル（Ctrl+C interrupt, rewind）が
+実際に機能することを定性的に示す。統制実験ではなく Case Study として記述。
 
-- [ ] Execute all experimental conditions (Paper Section 5.2)
-- [ ] Execute context window constraint conditions (Paper Section 5.3)
-- [ ] Collect all metrics (Paper Section 5.5)
-- [ ] Statistical analysis: significance tests, effect sizes
-- [ ] Results tables and figures for paper update
+- [ ] やまとさんが Claude Code + ACM MCP で実際のコーディング作業を 2-3 セッション実施
+- [ ] 意図的に interrupt (Ctrl+C) を発生させ、ACM が捕捉することを確認
+- [ ] experience DB にシグナル情報が記録されることを確認
+- [ ] 次セッションで経験が注入されることを確認
+- [ ] ログ / スクリーンショットで evidence を収集
 
-### Completion Criteria
+完了条件: PTY シグナルの capture → store → retrieve → inject サイクルが
+定性的に動作確認できること。論文 Section 5 の Case Study として記述可能な evidence が揃うこと。
 
-- Milestone 6-A: 10 runs completed, RQ1 傾向確認
-- Milestone 6-B: All 5 conditions × 3 context sizes × 3 tasks × 5 sessions = 225 runs completed
-- RQ1–RQ5 answered with statistical evidence
-- Results ready for paper Section 5 update
+**所要時間**: 半日程度
+
+### Milestone 6-B: Full Experimental Set（保留）
+
+論文 Section 5.2 の全条件（5条件 × 3コンテキストサイズ × 3タスク × 5セッション = 225回）。
+ASE 2026 の締切を考慮し、現時点では保留。6-D/6-E の結果を見てやまとさんが判断する。
 
 ### Corresponds to
 
@@ -209,15 +153,52 @@ null result（差が出ない）も「アルゴリズム実装タスクでは AC
 
 ---
 
+---
+
+## Phase 7: Paper Revision for ASE 2026
+
+*Phase 6 の結果を論文に反映し、ASE 2026 (締切: 2026-03-26) に投稿する。*
+
+### Deliverables
+
+- [ ] Section 5 の再構成:
+  - 5.1 Automated Pipeline — injection mechanism の定量評価（Task A-D）
+  - 5.2 Case Study — PTY signal capture の定性デモ
+  - 5.3 Results — 各タスクの結果表・分析
+- [ ] Section 5 Limitations の執筆:
+  - 自動実験は retrieval-injection pipeline を検証するが PTY シグナル (Level 1-3) は行使しない
+  - 定量的な人間実験は Future Work
+- [ ] Section 6 Discussion の更新:
+  - 天井効果の分析と含意
+  - 経験品質とACM効果の関係
+  - タスク難易度による効果の差異
+- [ ] Section 7 Future Work の更新:
+  - Human-in-the-loop 実験プロトコルの設計
+  - Multi-participant study
+  - PTY シグナルの定量的検証
+- [ ] 最終校正・フォーマット調整
+
+### Completion Criteria
+
+- Claims と Evidence の乖離が Limitations で明示的に扱われている
+- 全実験結果が正確に反映されている
+- ASE 2026 投稿フォーマットに準拠
+- 3/26 締切に提出
+
+---
+
 ## Dependencies
 
 ```
-Phase 0 (done) → Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6
-                                                    │
-                                                    └─ Phase 5 can start in parallel with Phase 4
+Phase 0-5 (COMPLETED) → Phase 6 → Phase 7
+                          │
+                          ├─ 6-D (Task D automated) ──┐
+                          ├─ 6-E (Case Study manual) ──┤→ Phase 7 (Paper Revision)
+                          └─ 6-B (Full set, 保留) ─────┘
 ```
 
-Phase 5 (task suite creation) is independent of Phases 2–4 and can be developed in parallel once Phase 1 infrastructure is in place.
+Phase 6-D と 6-E は並行して進められる。
+Phase 7 は 6-D/6-E の結果が揃い次第開始。
 
 ---
 

--- a/docs/session-log.md
+++ b/docs/session-log.md
@@ -313,3 +313,25 @@ Milestone 6-A（exp_6ac）の acm-sf 条件で null result が出た。DB 調査
 **改善後（exp_6ac_improved）**: s2 以降で 376→713→1050→1387 chars の injection が正常に蓄積
 
 ---
+
+#### Auto-logged: 2026-03-11 16:18 (session: 8cc82205)
+
+編集ファイル:
+- .claude/plans/scalable-drifting-walrus.md
+
+---
+
+#### Auto-logged: 2026-03-12 08:17 (session: 1f1777fe)
+
+編集ファイル:
+- .claude/plans/scalable-drifting-walrus.md
+
+---
+
+#### Auto-logged: 2026-03-12 09:09 (session: 591cee68)
+
+編集ファイル:
+- scripts/start-mcp.sh
+- src/index.ts
+
+---

--- a/experiments/results/dryrun_6a_001/dryrun_6a_001.csv
+++ b/experiments/results/dryrun_6a_001/dryrun_6a_001.csv
@@ -1,0 +1,11 @@
+run_id,condition,task,context_size,session_number,task_completion_rate,interrupt_count,corrective_instruction_count,context_tokens_used,duration_ms,error,timestamp
+control_task-a_full_s1,control,task-a,full,1,1,0,0,0,1,,2026-03-10T20:43:46.873Z
+control_task-a_full_s2,control,task-a,full,2,1,0,0,0,0,,2026-03-10T20:43:46.874Z
+control_task-a_full_s3,control,task-a,full,3,1,0,0,0,0,,2026-03-10T20:43:46.874Z
+control_task-a_full_s4,control,task-a,full,4,1,0,0,0,0,,2026-03-10T20:43:46.874Z
+control_task-a_full_s5,control,task-a,full,5,1,0,0,0,0,,2026-03-10T20:43:46.874Z
+acm-sf_task-a_full_s1,acm-sf,task-a,full,1,1,0,0,0,5,,2026-03-10T20:43:46.879Z
+acm-sf_task-a_full_s2,acm-sf,task-a,full,2,1,0,0,0,0,,2026-03-10T20:43:46.879Z
+acm-sf_task-a_full_s3,acm-sf,task-a,full,3,1,0,0,0,0,,2026-03-10T20:43:46.879Z
+acm-sf_task-a_full_s4,acm-sf,task-a,full,4,1,0,0,0,1,,2026-03-10T20:43:46.880Z
+acm-sf_task-a_full_s5,acm-sf,task-a,full,5,1,0,0,0,0,,2026-03-10T20:43:46.880Z

--- a/experiments/results/dryrun_6a_001/dryrun_6a_001.json
+++ b/experiments/results/dryrun_6a_001/dryrun_6a_001.json
@@ -1,0 +1,253 @@
+{
+  "experiment_id": "dryrun_6a_001",
+  "started_at": "2026-03-10T20:43:46.873Z",
+  "completed_at": "2026-03-10T20:43:46.880Z",
+  "runs": [
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 1,
+        "run_id": "control_task-a_full_s1"
+      },
+      "metrics": {
+        "run_id": "control_task-a_full_s1",
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 1,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:43:46.873Z"
+      },
+      "duration_ms": 1
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 2,
+        "run_id": "control_task-a_full_s2"
+      },
+      "metrics": {
+        "run_id": "control_task-a_full_s2",
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 2,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:43:46.874Z"
+      },
+      "duration_ms": 0
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 3,
+        "run_id": "control_task-a_full_s3"
+      },
+      "metrics": {
+        "run_id": "control_task-a_full_s3",
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 3,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:43:46.874Z"
+      },
+      "duration_ms": 0
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 4,
+        "run_id": "control_task-a_full_s4"
+      },
+      "metrics": {
+        "run_id": "control_task-a_full_s4",
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 4,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:43:46.874Z"
+      },
+      "duration_ms": 0
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 5,
+        "run_id": "control_task-a_full_s5"
+      },
+      "metrics": {
+        "run_id": "control_task-a_full_s5",
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 5,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:43:46.874Z"
+      },
+      "duration_ms": 0
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 1,
+        "run_id": "acm-sf_task-a_full_s1"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-a_full_s1",
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 1,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:43:46.879Z"
+      },
+      "duration_ms": 5
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 2,
+        "run_id": "acm-sf_task-a_full_s2"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-a_full_s2",
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 2,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:43:46.879Z"
+      },
+      "duration_ms": 0
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 3,
+        "run_id": "acm-sf_task-a_full_s3"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-a_full_s3",
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 3,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:43:46.879Z"
+      },
+      "duration_ms": 0
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 4,
+        "run_id": "acm-sf_task-a_full_s4"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-a_full_s4",
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 4,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:43:46.880Z"
+      },
+      "duration_ms": 1
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 5,
+        "run_id": "acm-sf_task-a_full_s5"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-a_full_s5",
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 5,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:43:46.880Z"
+      },
+      "duration_ms": 0
+    }
+  ],
+  "aggregated": [
+    {
+      "condition": "control",
+      "mean_completion_rate": 1,
+      "std_completion_rate": 0,
+      "mean_interrupt_count": 0,
+      "std_interrupt_count": 0,
+      "mean_corrective_count": 0,
+      "std_corrective_count": 0,
+      "mean_context_tokens": 0,
+      "std_context_tokens": 0,
+      "run_count": 5
+    },
+    {
+      "condition": "acm-sf",
+      "mean_completion_rate": 1,
+      "std_completion_rate": 0,
+      "mean_interrupt_count": 0,
+      "std_interrupt_count": 0,
+      "mean_corrective_count": 0,
+      "std_corrective_count": 0,
+      "mean_context_tokens": 0,
+      "std_context_tokens": 0,
+      "run_count": 5
+    }
+  ]
+}

--- a/experiments/results/exp_6a_20260311_054431/exp_6a_20260311_054431.csv
+++ b/experiments/results/exp_6a_20260311_054431/exp_6a_20260311_054431.csv
@@ -1,0 +1,11 @@
+run_id,condition,task,context_size,session_number,task_completion_rate,interrupt_count,corrective_instruction_count,context_tokens_used,duration_ms,error,timestamp
+control_task-a_full_s1,control,task-a,full,1,1,0,0,0,139817,,2026-03-10T20:46:52.433Z
+control_task-a_full_s2,control,task-a,full,2,1,0,0,0,159672,,2026-03-10T20:49:32.140Z
+control_task-a_full_s3,control,task-a,full,3,1,0,0,0,148193,,2026-03-10T20:52:00.365Z
+control_task-a_full_s4,control,task-a,full,4,1,0,0,0,123677,,2026-03-10T20:54:04.073Z
+control_task-a_full_s5,control,task-a,full,5,1,0,0,0,119847,,2026-03-10T20:56:03.951Z
+acm-sf_task-a_full_s1,acm-sf,task-a,full,1,1,0,0,0,214989,,2026-03-10T20:59:38.971Z
+acm-sf_task-a_full_s2,acm-sf,task-a,full,2,1,0,0,0,129907,,2026-03-10T21:01:48.912Z
+acm-sf_task-a_full_s3,acm-sf,task-a,full,3,1,0,0,0,105831,,2026-03-10T21:03:34.774Z
+acm-sf_task-a_full_s4,acm-sf,task-a,full,4,1,0,0,0,168923,,2026-03-10T21:06:23.729Z
+acm-sf_task-a_full_s5,acm-sf,task-a,full,5,1,0,0,0,132464,,2026-03-10T21:08:36.226Z

--- a/experiments/results/exp_6a_20260311_054431/exp_6a_20260311_054431.json
+++ b/experiments/results/exp_6a_20260311_054431/exp_6a_20260311_054431.json
@@ -1,0 +1,253 @@
+{
+  "experiment_id": "exp_6a_20260311_054431",
+  "started_at": "2026-03-10T20:46:52.433Z",
+  "completed_at": "2026-03-10T21:08:36.226Z",
+  "runs": [
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 1,
+        "run_id": "control_task-a_full_s1"
+      },
+      "metrics": {
+        "run_id": "control_task-a_full_s1",
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 1,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:46:52.433Z"
+      },
+      "duration_ms": 139817
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 2,
+        "run_id": "control_task-a_full_s2"
+      },
+      "metrics": {
+        "run_id": "control_task-a_full_s2",
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 2,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:49:32.140Z"
+      },
+      "duration_ms": 159672
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 3,
+        "run_id": "control_task-a_full_s3"
+      },
+      "metrics": {
+        "run_id": "control_task-a_full_s3",
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 3,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:52:00.365Z"
+      },
+      "duration_ms": 148193
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 4,
+        "run_id": "control_task-a_full_s4"
+      },
+      "metrics": {
+        "run_id": "control_task-a_full_s4",
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 4,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:54:04.073Z"
+      },
+      "duration_ms": 123677
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 5,
+        "run_id": "control_task-a_full_s5"
+      },
+      "metrics": {
+        "run_id": "control_task-a_full_s5",
+        "condition": "control",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 5,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:56:03.951Z"
+      },
+      "duration_ms": 119847
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 1,
+        "run_id": "acm-sf_task-a_full_s1"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-a_full_s1",
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 1,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T20:59:38.971Z"
+      },
+      "duration_ms": 214989
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 2,
+        "run_id": "acm-sf_task-a_full_s2"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-a_full_s2",
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 2,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:01:48.912Z"
+      },
+      "duration_ms": 129907
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 3,
+        "run_id": "acm-sf_task-a_full_s3"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-a_full_s3",
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 3,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:03:34.774Z"
+      },
+      "duration_ms": 105831
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 4,
+        "run_id": "acm-sf_task-a_full_s4"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-a_full_s4",
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 4,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:06:23.729Z"
+      },
+      "duration_ms": 168923
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 5,
+        "run_id": "acm-sf_task-a_full_s5"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-a_full_s5",
+        "condition": "acm-sf",
+        "task": "task-a",
+        "context_size": "full",
+        "session_number": 5,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:08:36.226Z"
+      },
+      "duration_ms": 132464
+    }
+  ],
+  "aggregated": [
+    {
+      "condition": "control",
+      "mean_completion_rate": 1,
+      "std_completion_rate": 0,
+      "mean_interrupt_count": 0,
+      "std_interrupt_count": 0,
+      "mean_corrective_count": 0,
+      "std_corrective_count": 0,
+      "mean_context_tokens": 0,
+      "std_context_tokens": 0,
+      "run_count": 5
+    },
+    {
+      "condition": "acm-sf",
+      "mean_completion_rate": 1,
+      "std_completion_rate": 0,
+      "mean_interrupt_count": 0,
+      "std_interrupt_count": 0,
+      "mean_corrective_count": 0,
+      "std_corrective_count": 0,
+      "mean_context_tokens": 0,
+      "std_context_tokens": 0,
+      "run_count": 5
+    }
+  ]
+}

--- a/experiments/results/exp_6ab_20260311_061355/exp_6ab_20260311_061355.csv
+++ b/experiments/results/exp_6ab_20260311_061355/exp_6ab_20260311_061355.csv
@@ -1,0 +1,11 @@
+run_id,condition,task,context_size,session_number,task_completion_rate,interrupt_count,corrective_instruction_count,context_tokens_used,duration_ms,error,timestamp
+control_task-b_full_s1,control,task-b,full,1,1,0,0,0,158348,,2026-03-10T21:16:34.437Z
+control_task-b_full_s2,control,task-b,full,2,1,0,0,0,207461,,2026-03-10T21:20:01.932Z
+control_task-b_full_s3,control,task-b,full,3,1,0,0,0,132373,,2026-03-10T21:22:14.344Z
+control_task-b_full_s4,control,task-b,full,4,1,0,0,0,181412,,2026-03-10T21:25:15.792Z
+control_task-b_full_s5,control,task-b,full,5,1,0,0,0,143766,,2026-03-10T21:27:39.603Z
+acm-sf_task-b_full_s1,acm-sf,task-b,full,1,1,0,0,0,141231,,2026-03-10T21:30:00.871Z
+acm-sf_task-b_full_s2,acm-sf,task-b,full,2,1,0,0,0,124160,,2026-03-10T21:32:05.066Z
+acm-sf_task-b_full_s3,acm-sf,task-b,full,3,1,0,0,0,128061,,2026-03-10T21:34:13.161Z
+acm-sf_task-b_full_s4,acm-sf,task-b,full,4,1,0,0,0,129965,,2026-03-10T21:36:23.161Z
+acm-sf_task-b_full_s5,acm-sf,task-b,full,5,1,0,0,0,112219,,2026-03-10T21:38:15.423Z

--- a/experiments/results/exp_6ab_20260311_061355/exp_6ab_20260311_061355.json
+++ b/experiments/results/exp_6ab_20260311_061355/exp_6ab_20260311_061355.json
@@ -1,0 +1,253 @@
+{
+  "experiment_id": "exp_6ab_20260311_061355",
+  "started_at": "2026-03-10T21:16:34.437Z",
+  "completed_at": "2026-03-10T21:38:15.423Z",
+  "runs": [
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 1,
+        "run_id": "control_task-b_full_s1"
+      },
+      "metrics": {
+        "run_id": "control_task-b_full_s1",
+        "condition": "control",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 1,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:16:34.437Z"
+      },
+      "duration_ms": 158348
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 2,
+        "run_id": "control_task-b_full_s2"
+      },
+      "metrics": {
+        "run_id": "control_task-b_full_s2",
+        "condition": "control",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 2,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:20:01.932Z"
+      },
+      "duration_ms": 207461
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 3,
+        "run_id": "control_task-b_full_s3"
+      },
+      "metrics": {
+        "run_id": "control_task-b_full_s3",
+        "condition": "control",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 3,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:22:14.344Z"
+      },
+      "duration_ms": 132373
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 4,
+        "run_id": "control_task-b_full_s4"
+      },
+      "metrics": {
+        "run_id": "control_task-b_full_s4",
+        "condition": "control",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 4,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:25:15.792Z"
+      },
+      "duration_ms": 181412
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 5,
+        "run_id": "control_task-b_full_s5"
+      },
+      "metrics": {
+        "run_id": "control_task-b_full_s5",
+        "condition": "control",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 5,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:27:39.603Z"
+      },
+      "duration_ms": 143766
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 1,
+        "run_id": "acm-sf_task-b_full_s1"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-b_full_s1",
+        "condition": "acm-sf",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 1,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:30:00.871Z"
+      },
+      "duration_ms": 141231
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 2,
+        "run_id": "acm-sf_task-b_full_s2"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-b_full_s2",
+        "condition": "acm-sf",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 2,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:32:05.066Z"
+      },
+      "duration_ms": 124160
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 3,
+        "run_id": "acm-sf_task-b_full_s3"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-b_full_s3",
+        "condition": "acm-sf",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 3,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:34:13.161Z"
+      },
+      "duration_ms": 128061
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 4,
+        "run_id": "acm-sf_task-b_full_s4"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-b_full_s4",
+        "condition": "acm-sf",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 4,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:36:23.161Z"
+      },
+      "duration_ms": 129965
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 5,
+        "run_id": "acm-sf_task-b_full_s5"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-b_full_s5",
+        "condition": "acm-sf",
+        "task": "task-b",
+        "context_size": "full",
+        "session_number": 5,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:38:15.423Z"
+      },
+      "duration_ms": 112219
+    }
+  ],
+  "aggregated": [
+    {
+      "condition": "control",
+      "mean_completion_rate": 1,
+      "std_completion_rate": 0,
+      "mean_interrupt_count": 0,
+      "std_interrupt_count": 0,
+      "mean_corrective_count": 0,
+      "std_corrective_count": 0,
+      "mean_context_tokens": 0,
+      "std_context_tokens": 0,
+      "run_count": 5
+    },
+    {
+      "condition": "acm-sf",
+      "mean_completion_rate": 1,
+      "std_completion_rate": 0,
+      "mean_interrupt_count": 0,
+      "std_interrupt_count": 0,
+      "mean_corrective_count": 0,
+      "std_corrective_count": 0,
+      "mean_context_tokens": 0,
+      "std_context_tokens": 0,
+      "run_count": 5
+    }
+  ]
+}

--- a/experiments/results/exp_6ac_20260311_061356/exp_6ac_20260311_061356.csv
+++ b/experiments/results/exp_6ac_20260311_061356/exp_6ac_20260311_061356.csv
@@ -1,0 +1,11 @@
+run_id,condition,task,context_size,session_number,task_completion_rate,interrupt_count,corrective_instruction_count,context_tokens_used,duration_ms,error,timestamp
+control_task-c_full_s1,control,task-c,full,1,0.9375,0,0,0,245611,,2026-03-10T21:18:03.315Z
+control_task-c_full_s2,control,task-c,full,2,0.9375,0,0,0,278404,,2026-03-10T21:22:41.753Z
+control_task-c_full_s3,control,task-c,full,3,1,0,0,0,324949,,2026-03-10T21:28:06.733Z
+control_task-c_full_s4,control,task-c,full,4,0.9375,0,0,0,214385,,2026-03-10T21:31:41.373Z
+control_task-c_full_s5,control,task-c,full,5,0.75,0,0,0,158304,,2026-03-10T21:34:19.711Z
+acm-sf_task-c_full_s1,acm-sf,task-c,full,1,0.75,0,0,0,229840,,2026-03-10T21:38:09.584Z
+acm-sf_task-c_full_s2,acm-sf,task-c,full,2,0.9375,0,0,0,271705,,2026-03-10T21:42:41.335Z
+acm-sf_task-c_full_s3,acm-sf,task-c,full,3,0.9375,0,0,0,216024,,2026-03-10T21:46:17.393Z
+acm-sf_task-c_full_s4,acm-sf,task-c,full,4,0.9375,0,0,0,259806,,2026-03-10T21:50:37.233Z
+acm-sf_task-c_full_s5,acm-sf,task-c,full,5,0.75,0,0,0,134742,,2026-03-10T21:52:52.009Z

--- a/experiments/results/exp_6ac_20260311_061356/exp_6ac_20260311_061356.json
+++ b/experiments/results/exp_6ac_20260311_061356/exp_6ac_20260311_061356.json
@@ -1,0 +1,253 @@
+{
+  "experiment_id": "exp_6ac_20260311_061356",
+  "started_at": "2026-03-10T21:18:03.315Z",
+  "completed_at": "2026-03-10T21:52:52.009Z",
+  "runs": [
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 1,
+        "run_id": "control_task-c_full_s1"
+      },
+      "metrics": {
+        "run_id": "control_task-c_full_s1",
+        "condition": "control",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 1,
+        "task_completion_rate": 0.9375,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:18:03.315Z"
+      },
+      "duration_ms": 245611
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 2,
+        "run_id": "control_task-c_full_s2"
+      },
+      "metrics": {
+        "run_id": "control_task-c_full_s2",
+        "condition": "control",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 2,
+        "task_completion_rate": 0.9375,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:22:41.753Z"
+      },
+      "duration_ms": 278404
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 3,
+        "run_id": "control_task-c_full_s3"
+      },
+      "metrics": {
+        "run_id": "control_task-c_full_s3",
+        "condition": "control",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 3,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:28:06.733Z"
+      },
+      "duration_ms": 324949
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 4,
+        "run_id": "control_task-c_full_s4"
+      },
+      "metrics": {
+        "run_id": "control_task-c_full_s4",
+        "condition": "control",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 4,
+        "task_completion_rate": 0.9375,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:31:41.373Z"
+      },
+      "duration_ms": 214385
+    },
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 5,
+        "run_id": "control_task-c_full_s5"
+      },
+      "metrics": {
+        "run_id": "control_task-c_full_s5",
+        "condition": "control",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 5,
+        "task_completion_rate": 0.75,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:34:19.711Z"
+      },
+      "duration_ms": 158304
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 1,
+        "run_id": "acm-sf_task-c_full_s1"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-c_full_s1",
+        "condition": "acm-sf",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 1,
+        "task_completion_rate": 0.75,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:38:09.584Z"
+      },
+      "duration_ms": 229840
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 2,
+        "run_id": "acm-sf_task-c_full_s2"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-c_full_s2",
+        "condition": "acm-sf",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 2,
+        "task_completion_rate": 0.9375,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:42:41.335Z"
+      },
+      "duration_ms": 271705
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 3,
+        "run_id": "acm-sf_task-c_full_s3"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-c_full_s3",
+        "condition": "acm-sf",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 3,
+        "task_completion_rate": 0.9375,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:46:17.393Z"
+      },
+      "duration_ms": 216024
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 4,
+        "run_id": "acm-sf_task-c_full_s4"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-c_full_s4",
+        "condition": "acm-sf",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 4,
+        "task_completion_rate": 0.9375,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:50:37.233Z"
+      },
+      "duration_ms": 259806
+    },
+    {
+      "spec": {
+        "condition": "acm-sf",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 5,
+        "run_id": "acm-sf_task-c_full_s5"
+      },
+      "metrics": {
+        "run_id": "acm-sf_task-c_full_s5",
+        "condition": "acm-sf",
+        "task": "task-c",
+        "context_size": "full",
+        "session_number": 5,
+        "task_completion_rate": 0.75,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T21:52:52.009Z"
+      },
+      "duration_ms": 134742
+    }
+  ],
+  "aggregated": [
+    {
+      "condition": "control",
+      "mean_completion_rate": 0.9125,
+      "std_completion_rate": 0.09478594305064438,
+      "mean_interrupt_count": 0,
+      "std_interrupt_count": 0,
+      "mean_corrective_count": 0,
+      "std_corrective_count": 0,
+      "mean_context_tokens": 0,
+      "std_context_tokens": 0,
+      "run_count": 5
+    },
+    {
+      "condition": "acm-sf",
+      "mean_completion_rate": 0.8625,
+      "std_completion_rate": 0.10269797953221865,
+      "mean_interrupt_count": 0,
+      "std_interrupt_count": 0,
+      "mean_corrective_count": 0,
+      "std_corrective_count": 0,
+      "mean_context_tokens": 0,
+      "std_context_tokens": 0,
+      "run_count": 5
+    }
+  ]
+}

--- a/experiments/results/probe_no_skills_6d/probe_no_skills_6d.csv
+++ b/experiments/results/probe_no_skills_6d/probe_no_skills_6d.csv
@@ -1,0 +1,2 @@
+run_id,condition,task,context_size,session_number,task_completion_rate,interrupt_count,corrective_instruction_count,context_tokens_used,duration_ms,error,timestamp
+control_task-d_full_s1,control,task-d,full,1,1,0,0,0,239484,,2026-03-11T00:24:15.946Z

--- a/experiments/results/probe_no_skills_6d/probe_no_skills_6d.json
+++ b/experiments/results/probe_no_skills_6d/probe_no_skills_6d.json
@@ -1,0 +1,43 @@
+{
+  "experiment_id": "probe_no_skills_6d",
+  "started_at": "2026-03-11T00:24:15.946Z",
+  "completed_at": "2026-03-11T00:24:15.946Z",
+  "runs": [
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-d",
+        "context_size": "full",
+        "session_number": 1,
+        "run_id": "control_task-d_full_s1"
+      },
+      "metrics": {
+        "run_id": "control_task-d_full_s1",
+        "condition": "control",
+        "task": "task-d",
+        "context_size": "full",
+        "session_number": 1,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-11T00:24:15.946Z"
+      },
+      "duration_ms": 239484
+    }
+  ],
+  "aggregated": [
+    {
+      "condition": "control",
+      "mean_completion_rate": 1,
+      "std_completion_rate": 0,
+      "mean_interrupt_count": 0,
+      "std_interrupt_count": 0,
+      "mean_corrective_count": 0,
+      "std_corrective_count": 0,
+      "mean_context_tokens": 0,
+      "std_context_tokens": 0,
+      "run_count": 1
+    }
+  ]
+}

--- a/experiments/results/probe_pipeline_6d/probe_pipeline_6d.csv
+++ b/experiments/results/probe_pipeline_6d/probe_pipeline_6d.csv
@@ -1,0 +1,2 @@
+run_id,condition,task,context_size,session_number,task_completion_rate,interrupt_count,corrective_instruction_count,context_tokens_used,duration_ms,error,timestamp
+control_task-d_full_s1,control,task-d,full,1,1,0,0,0,263127,,2026-03-10T23:51:39.883Z

--- a/experiments/results/probe_pipeline_6d/probe_pipeline_6d.json
+++ b/experiments/results/probe_pipeline_6d/probe_pipeline_6d.json
@@ -1,0 +1,43 @@
+{
+  "experiment_id": "probe_pipeline_6d",
+  "started_at": "2026-03-10T23:51:39.883Z",
+  "completed_at": "2026-03-10T23:51:39.883Z",
+  "runs": [
+    {
+      "spec": {
+        "condition": "control",
+        "task": "task-d",
+        "context_size": "full",
+        "session_number": 1,
+        "run_id": "control_task-d_full_s1"
+      },
+      "metrics": {
+        "run_id": "control_task-d_full_s1",
+        "condition": "control",
+        "task": "task-d",
+        "context_size": "full",
+        "session_number": 1,
+        "task_completion_rate": 1,
+        "interrupt_count": 0,
+        "corrective_instruction_count": 0,
+        "context_tokens_used": 0,
+        "timestamp": "2026-03-10T23:51:39.883Z"
+      },
+      "duration_ms": 263127
+    }
+  ],
+  "aggregated": [
+    {
+      "condition": "control",
+      "mean_completion_rate": 1,
+      "std_completion_rate": 0,
+      "mean_interrupt_count": 0,
+      "std_interrupt_count": 0,
+      "mean_corrective_count": 0,
+      "std_corrective_count": 0,
+      "mean_context_tokens": 0,
+      "std_context_tokens": 0,
+      "run_count": 1
+    }
+  ]
+}

--- a/experiments/tasks/task-a-bugfix/package-lock.json
+++ b/experiments/tasks/task-a-bugfix/package-lock.json
@@ -1,0 +1,1480 @@
+{
+  "name": "task-a-bugfix",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "task-a-bugfix",
+      "version": "1.0.0",
+      "devDependencies": {
+        "typescript": "^5.9.0",
+        "vitest": "^4.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Milestone 6-A (Task A bugfix), 6-AB (Task B refactoring), 6-AC (Task C validation), 6-D (orbitscore) の実験結果を追加
- ドライラン結果 (dryrun_6a_001) とプローブ結果 (probe_no_skills_6d, probe_pipeline_6d) を含む
- docs/ROADMAP.md と docs/session-log.md の更新

## Test plan
- [x] データファイル（CSV/JSON）が正しくコミットされていること
- [x] .db ファイルは .gitignore により除外されていること
- [x] 全384テストがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)