### PR TITLE
feat: CL Metrics Engine (#106)

### DIFF
--- a/experiments/benchmarks/__tests__/cl-metrics.test.ts
+++ b/experiments/benchmarks/__tests__/cl-metrics.test.ts
@@ -16,6 +16,50 @@ import {
   computeAllCLMetrics,
 } from "../cl-metrics.js";
 
+// --- Input validation ---
+
+describe("input validation", () => {
+  it("throws RangeError for non-square matrix in computeForwardTransfer", () => {
+    const a = [
+      [0.8, 0.7, 0.6],
+      [0.9, 0.9],
+    ];
+    expect(() => computeForwardTransfer(a, [0.5, 0.4, 0.3])).toThrow(RangeError);
+  });
+
+  it("throws RangeError for non-square matrix in computeForgetting", () => {
+    const a = [
+      [0.8, 0.7],
+      [0.9, 0.9, 0.8],
+    ];
+    expect(() => computeForgetting(a)).toThrow(RangeError);
+  });
+
+  it("throws RangeError when baseline is shorter than matrix size", () => {
+    const a = [
+      [0.8, 0.7],
+      [0.7, 0.9],
+    ];
+    expect(() => computeForwardTransfer(a, [0.5])).toThrow(RangeError);
+  });
+
+  it("throws RangeError for non-square matrix in computeAllCLMetrics", () => {
+    const a = [
+      [0.8, 0.7, 0.6],
+      [0.9, 0.9],
+    ];
+    expect(() => computeAllCLMetrics(a, [0.5, 0.4, 0.3])).toThrow(RangeError);
+  });
+
+  it("throws RangeError when baseline is shorter in computeAllCLMetrics", () => {
+    const a = [
+      [0.8, 0.7],
+      [0.7, 0.9],
+    ];
+    expect(() => computeAllCLMetrics(a, [0.5])).toThrow(RangeError);
+  });
+});
+
 // --- computeForwardTransfer ---
 // FT = (1/(N-1)) * Σ_{i=0}^{N-2} (a[i][i+1] - baseline[i+1])
 // Superdiagonal: after training on task i, performance on task i+1
@@ -91,9 +135,9 @@ describe("computeForgetting", () => {
     expect(computeForgetting(a)).toBeCloseTo(0.15, 4);
   });
 
-  it("returns 0 for single session (no forgetting possible)", () => {
+  it("throws RangeError for non-square matrix", () => {
     const a = [[0.5], [0.7]];
-    expect(computeForgetting(a)).toBe(0);
+    expect(() => computeForgetting(a)).toThrow(RangeError);
   });
 
   it("returns 0 for empty matrix", () => {
@@ -135,10 +179,12 @@ describe("computeCLFbeta", () => {
       [0.8, 0.7],
       [0.7, 0.9],
     ];
-    const baseline = [0.5, 0.6];
-    const result = computeCLFbeta(a, baseline);
-    expect(result).toBeGreaterThan(0);
-    expect(result).toBeLessThanOrEqual(1);
+    const result = computeCLFbeta(a);
+    // Plasticity = (0.8+0.9)/2 = 0.85
+    // Forgetting: col 0: max(0.8,0.7)=0.8, final=0.7, f=0.1 → mean=0.1
+    // Stability = 1 - 0.1 = 0.9
+    // Fβ(1) = 2*0.85*0.9 / (0.85+0.9) = 1.53/1.75 ≈ 0.8743
+    expect(result).toBeCloseTo(0.8743, 3);
   });
 
   it("returns 0 when plasticity is 0", () => {
@@ -146,20 +192,16 @@ describe("computeCLFbeta", () => {
       [0.0, 0.5],
       [0.3, 0.0],
     ];
-    const baseline = [0.5, 0.5];
-    expect(computeCLFbeta(a, baseline)).toBe(0);
+    expect(computeCLFbeta(a)).toBe(0);
   });
 
   it("returns 0 when stability is 0 (complete forgetting)", () => {
-    // Column 0: [1.0, 0.0] → max=1.0, final=0.0 → forgetting=1.0
-    // Column 1: excluded
-    // stability = max(0, 1 - 1.0) = 0
+    // Column 0: [1.0, 0.0] → forgetting=1.0, stability=0
     const a = [
       [1.0, 0.0],
       [0.0, 0.5],
     ];
-    const baseline = [0.5, 0.5];
-    expect(computeCLFbeta(a, baseline)).toBe(0);
+    expect(computeCLFbeta(a)).toBe(0);
   });
 
   it("uses default beta=1 (equal weight)", () => {
@@ -167,9 +209,8 @@ describe("computeCLFbeta", () => {
       [0.8, 0.7],
       [0.7, 0.9],
     ];
-    const baseline = [0.5, 0.6];
-    const defaultResult = computeCLFbeta(a, baseline);
-    const beta1Result = computeCLFbeta(a, baseline, 1);
+    const defaultResult = computeCLFbeta(a);
+    const beta1Result = computeCLFbeta(a, 1);
     expect(defaultResult).toBeCloseTo(beta1Result, 10);
   });
 
@@ -178,14 +219,13 @@ describe("computeCLFbeta", () => {
       [0.8, 0.7],
       [0.7, 0.9],
     ];
-    const baseline = [0.5, 0.6];
-    const beta1 = computeCLFbeta(a, baseline, 1);
-    const beta2 = computeCLFbeta(a, baseline, 2);
+    const beta1 = computeCLFbeta(a, 1);
+    const beta2 = computeCLFbeta(a, 2);
     expect(beta1).not.toBeCloseTo(beta2, 4);
   });
 
   it("returns 0 for empty matrix", () => {
-    expect(computeCLFbeta([], [])).toBe(0);
+    expect(computeCLFbeta([])).toBe(0);
   });
 });
 
@@ -264,7 +304,7 @@ describe("computeAllCLMetrics", () => {
     expect(result.forgetting).toBeCloseTo(computeForgetting(a), 10);
 
     // cl_f_beta matches standalone
-    expect(result.cl_f_beta).toBeCloseTo(computeCLFbeta(a, baseline), 10);
+    expect(result.cl_f_beta).toBeCloseTo(computeCLFbeta(a), 10);
   });
 
   it("handles perfect scenario (no forgetting, high performance)", () => {

--- a/experiments/benchmarks/__tests__/cl-metrics.test.ts
+++ b/experiments/benchmarks/__tests__/cl-metrics.test.ts
@@ -58,6 +58,33 @@ describe("input validation", () => {
     ];
     expect(() => computeAllCLMetrics(a, [0.5])).toThrow(RangeError);
   });
+
+  it("throws RangeError for non-square matrix in computeCLFbeta", () => {
+    const a = [
+      [0.8, 0.7, 0.6],
+      [0.9, 0.9],
+    ];
+    expect(() => computeCLFbeta(a)).toThrow(RangeError);
+  });
+
+  it("throws RangeError for matrix containing NaN", () => {
+    const a = [
+      [NaN, 0.7],
+      [0.7, 0.9],
+    ];
+    expect(() => computeForwardTransfer(a, [0.5, 0.6])).toThrow(RangeError);
+    expect(() => computeForgetting(a)).toThrow(RangeError);
+    expect(() => computeCLFbeta(a)).toThrow(RangeError);
+    expect(() => computeAllCLMetrics(a, [0.5, 0.6])).toThrow(RangeError);
+  });
+
+  it("throws RangeError for matrix containing Infinity", () => {
+    const a = [
+      [0.8, Infinity],
+      [0.7, 0.9],
+    ];
+    expect(() => computeForgetting(a)).toThrow(RangeError);
+  });
 });
 
 // --- computeForwardTransfer ---
@@ -106,13 +133,13 @@ describe("computeForwardTransfer", () => {
 });
 
 // --- computeForgetting ---
-// F = (1/(N-1)) * Σ_{j=0}^{N-2} (max_k a[k][j] - a[N-1][j])
-// Reads columns, excludes last eval task. N-1 denominator.
+// F = (1/(N-1)) * Σ_{j=0}^{N-2} max(0, max_{k=0}^{j} a[k][j] - a[N-1][j])
+// Reads columns, peak up to stage j. Excludes last eval task. N-1 denominator.
 
 describe("computeForgetting", () => {
   it("returns 0 when final performance matches peak (no degradation)", () => {
-    // Column 0 (task 0): [0.5, 0.6, 0.7] → max=0.7, final=0.7 → 0
-    // Column 1 (task 1): [0.0, 0.4, 0.5] → max=0.5, final=0.5 → 0
+    // Column 0 (task 0): max_{k=0}^{0}=0.5, final=0.7 → max(0, 0.5-0.7)=0
+    // Column 1 (task 1): max_{k=0}^{1}=max(0.0,0.4)=0.4, final=0.5 → max(0, 0.4-0.5)=0
     // Column 2 excluded (last eval task)
     const a = [
       [0.5, 0.0, 0.0],
@@ -123,8 +150,8 @@ describe("computeForgetting", () => {
   });
 
   it("returns positive value when final performance drops from peak", () => {
-    // Column 0 (task 0): [0.9, 0.8, 0.6] → max=0.9, final=0.6 → 0.3
-    // Column 1 (task 1): [0.0, 0.7, 0.7] → max=0.7, final=0.7 → 0.0
+    // Column 0 (task 0): max_{k=0}^{0}=0.9, final=0.6 → 0.3
+    // Column 1 (task 1): max_{k=0}^{1}=max(0.0,0.7)=0.7, final=0.7 → 0.0
     // Column 2 excluded (last eval task)
     // Mean = (0.3 + 0.0) / 2 = 0.15
     const a = [
@@ -145,12 +172,11 @@ describe("computeForgetting", () => {
   });
 
   it("returns 0 for N=1 (single training stage)", () => {
-    const a = [[0.9, 0.7, 0.6]];
-    expect(computeForgetting(a)).toBe(0);
+    expect(computeForgetting([[0.9]])).toBe(0);
   });
 
   it("handles constant performance across training stages", () => {
-    // Column 0: [0.5, 0.5] → max=0.5, final=0.5 → 0
+    // Column 0: max_{k=0}^{0}=0.5, final=0.5 → 0
     // Column 1 excluded
     const a = [
       [0.5, 0.0],
@@ -160,7 +186,7 @@ describe("computeForgetting", () => {
   });
 
   it("computes correctly with two tasks", () => {
-    // Column 0 (task 0): [0.9, 0.6] → max=0.9, final=0.6 → 0.3
+    // Column 0 (task 0): max_{k=0}^{0}=0.9, final=0.6 → 0.3
     // Column 1 excluded (last eval task)
     // Mean = 0.3 / 1 = 0.3
     const a = [
@@ -168,6 +194,15 @@ describe("computeForgetting", () => {
       [0.6, 0.8],
     ];
     expect(computeForgetting(a)).toBeCloseTo(0.3, 4);
+  });
+
+  it("forgetting is never negative (clamped at 0)", () => {
+    // Final row outperforms all prior rows on task 0
+    const a = [
+      [0.5, 0.0],
+      [0.7, 0.8],
+    ];
+    expect(computeForgetting(a)).toBeGreaterThanOrEqual(0);
   });
 });
 
@@ -181,7 +216,7 @@ describe("computeCLFbeta", () => {
     ];
     const result = computeCLFbeta(a);
     // Plasticity = (0.8+0.9)/2 = 0.85
-    // Forgetting: col 0: max(0.8,0.7)=0.8, final=0.7, f=0.1 → mean=0.1
+    // Forgetting: col 0: max_{k=0}^{0}=0.8, final=0.7, f=0.1 → mean=0.1
     // Stability = 1 - 0.1 = 0.9
     // Fβ(1) = 2*0.85*0.9 / (0.85+0.9) = 1.53/1.75 ≈ 0.8743
     expect(result).toBeCloseTo(0.8743, 3);
@@ -196,7 +231,7 @@ describe("computeCLFbeta", () => {
   });
 
   it("returns 0 when stability is 0 (complete forgetting)", () => {
-    // Column 0: [1.0, 0.0] → forgetting=1.0, stability=0
+    // Column 0: max_{k=0}^{0}=1.0, final=0.0 → forgetting=1.0, stability=0
     const a = [
       [1.0, 0.0],
       [0.0, 0.5],
@@ -227,6 +262,31 @@ describe("computeCLFbeta", () => {
   it("returns 0 for empty matrix", () => {
     expect(computeCLFbeta([])).toBe(0);
   });
+
+  it("cl_f_beta is always in [0, 1] for performance values in [0, 1]", () => {
+    const a1 = [
+      [0.9, 0.8],
+      [0.85, 0.95],
+    ];
+    expect(computeCLFbeta(a1)).toBeGreaterThanOrEqual(0);
+    expect(computeCLFbeta(a1)).toBeLessThanOrEqual(1);
+
+    const a2 = [
+      [1.0, 0.0],
+      [0.5, 0.9],
+    ];
+    expect(computeCLFbeta(a2)).toBeGreaterThanOrEqual(0);
+    expect(computeCLFbeta(a2)).toBeLessThanOrEqual(1);
+  });
+
+  it("handles beta=0 without division by zero", () => {
+    const a = [
+      [0.8, 0.7],
+      [0.7, 0.9],
+    ];
+    expect(() => computeCLFbeta(a, 0)).not.toThrow();
+    expect(Number.isFinite(computeCLFbeta(a, 0))).toBe(true);
+  });
 });
 
 // --- computeCLScore ---
@@ -245,7 +305,7 @@ describe("computeCLScore", () => {
 
     // ACC = mean of last row = (0.7 + 0.9) / 2 = 0.8
     // FWT = (a[0][1] - baseline[1]) / 1 = (0.7 - 0.6) / 1 = 0.1
-    // Forgetting: col 0 only: max(0.8,0.7)=0.8, final=0.7, f=0.1 → mean=0.1/1=0.1
+    // Forgetting: col 0 only: max_{k=0}^{0}=0.8, final=0.7, f=0.1 → mean=0.1/1=0.1
     // CL-Score = 0.8 + 0.1 - 0.1 = 0.8
     expect(score).toBeCloseTo(0.8, 4);
   });
@@ -303,12 +363,12 @@ describe("computeAllCLMetrics", () => {
     // forgetting matches standalone
     expect(result.forgetting).toBeCloseTo(computeForgetting(a), 10);
 
-    // cl_f_beta matches standalone
+    // cl_f_beta matches standalone (both use β=1)
     expect(result.cl_f_beta).toBeCloseTo(computeCLFbeta(a), 10);
   });
 
   it("handles perfect scenario (no forgetting, high performance)", () => {
-    // Column 0: [1.0, 1.0] → max=1.0, final=1.0 → 0 forgetting
+    // Column 0: max_{k=0}^{0}=1.0, final=1.0 → 0 forgetting
     // Column 1: excluded
     const a = [
       [1.0, 0.5],
@@ -337,9 +397,9 @@ describe("computeAllCLMetrics", () => {
     // Plasticity = mean diagonal = (0.9 + 0.8 + 0.8) / 3 ≈ 0.8333
     expect(result.plasticity).toBeCloseTo(0.8333, 3);
 
-    // Forgetting (cols 0,1 only, exclude col 2):
-    // col 0: max(0.9,0.7,0.6)=0.9, final=0.6, f=0.3
-    // col 1: max(0.3,0.8,0.7)=0.8, final=0.7, f=0.1
+    // Forgetting (cols 0,1 only, exclude col 2, max up to stage j):
+    // col 0: max_{k=0}^{0}=0.9, final=0.6, f=0.3
+    // col 1: max_{k=0}^{1}=max(0.3,0.8)=0.8, final=0.7, f=0.1
     // mean = (0.3 + 0.1) / 2 = 0.2
     expect(result.forgetting).toBeCloseTo(0.2, 4);
 

--- a/experiments/benchmarks/__tests__/cl-metrics.test.ts
+++ b/experiments/benchmarks/__tests__/cl-metrics.test.ts
@@ -85,6 +85,23 @@ describe("input validation", () => {
     ];
     expect(() => computeForgetting(a)).toThrow(RangeError);
   });
+
+  it("throws RangeError for baseline containing NaN", () => {
+    const a = [
+      [0.8, 0.7],
+      [0.7, 0.9],
+    ];
+    expect(() => computeForwardTransfer(a, [0.5, NaN])).toThrow(RangeError);
+    expect(() => computeAllCLMetrics(a, [NaN, 0.6])).toThrow(RangeError);
+  });
+
+  it("throws RangeError for non-square matrix in computeCLScore", () => {
+    const a = [
+      [0.8, 0.7, 0.6],
+      [0.9, 0.9],
+    ];
+    expect(() => computeCLScore(a, [0.5, 0.4, 0.3])).toThrow(RangeError);
+  });
 });
 
 // --- computeForwardTransfer ---
@@ -194,6 +211,21 @@ describe("computeForgetting", () => {
       [0.6, 0.8],
     ];
     expect(computeForgetting(a)).toBeCloseTo(0.3, 4);
+  });
+
+  it("excludes later training stages from peak (k<=j bound)", () => {
+    // a[2][0] = 0.95 is a later-stage spike for task 0 that must NOT count as peak
+    // peak for task 0: max_{k=0}^{0} = a[0][0] = 0.9
+    // peak for task 1: max_{k=0}^{1} = max(0.3, 0.8) = 0.8
+    // final[0] = 0.95 → max(0, 0.9 - 0.95) = 0
+    // final[1] = 0.7  → max(0, 0.8 - 0.7) = 0.1
+    // mean = (0 + 0.1) / 2 = 0.05
+    const a = [
+      [0.9, 0.3, 0.2],
+      [0.7, 0.8, 0.5],
+      [0.95, 0.7, 0.9],
+    ];
+    expect(computeForgetting(a)).toBeCloseTo(0.05, 4);
   });
 
   it("forgetting is never negative (clamped at 0)", () => {

--- a/experiments/benchmarks/__tests__/cl-metrics.test.ts
+++ b/experiments/benchmarks/__tests__/cl-metrics.test.ts
@@ -3,6 +3,9 @@
  *
  * Pure function tests based on SWE-Bench-CL (arXiv:2507.00014) Section 7 metrics.
  * No mocks needed — all functions are pure.
+ *
+ * Matrix convention (paper): a[i][j] = performance on task j after training through task i.
+ * Rows = training stage, Columns = evaluation task.
  */
 import { describe, it, expect } from "vitest";
 import {
@@ -15,41 +18,41 @@ import {
 
 // --- computeForwardTransfer ---
 // FT = (1/(N-1)) * Σ_{i=0}^{N-2} (a[i][i+1] - baseline[i+1])
-// Uses superdiagonal: after training on task i, performance on task i+1
+// Superdiagonal: after training on task i, performance on task i+1
 
 describe("computeForwardTransfer", () => {
   it("returns positive value when ACM transfers to next task better than baseline", () => {
-    // sessions[0][1] = 0.7 (task 0 trained, eval task 1) vs baseline[1] = 0.4
-    // sessions[1][2] = 0.8 (task 1 trained, eval task 2) vs baseline[2] = 0.3
-    // FWT = ((0.7-0.4) + (0.8-0.3)) / 2 = (0.3 + 0.5) / 2 = 0.4
-    const sessions = [
-      [0.8, 0.7, 0.6],
-      [0.0, 0.9, 0.8],
-      [0.0, 0.0, 0.7],
+    // a[0][1] = 0.7 (after training task 0, eval task 1) vs baseline[1] = 0.4
+    // a[1][2] = 0.8 (after training task 1, eval task 2) vs baseline[2] = 0.3
+    // FWT = ((0.7-0.4) + (0.8-0.3)) / 2 = 0.4
+    const a = [
+      [0.8, 0.7, 0.6], // trained through task 0
+      [0.9, 0.9, 0.8], // trained through task 1
+      [0.8, 0.8, 0.7], // trained through task 2
     ];
     const baseline = [0.5, 0.4, 0.3];
-    expect(computeForwardTransfer(sessions, baseline)).toBeCloseTo(0.4, 4);
+    expect(computeForwardTransfer(a, baseline)).toBeCloseTo(0.4, 4);
   });
 
   it("returns 0 when superdiagonal equals baseline", () => {
-    const sessions = [
+    const a = [
       [0.8, 0.6], // a[0][1] = 0.6 == baseline[1]
-      [0.0, 0.9],
+      [0.7, 0.9], // trained through task 1
     ];
     const baseline = [0.5, 0.6];
-    expect(computeForwardTransfer(sessions, baseline)).toBeCloseTo(0, 4);
+    expect(computeForwardTransfer(a, baseline)).toBeCloseTo(0, 4);
   });
 
   it("returns negative when baseline outperforms superdiagonal", () => {
-    const sessions = [
+    const a = [
       [0.8, 0.3], // a[0][1] = 0.3 < baseline[1] = 0.6
-      [0.0, 0.7],
+      [0.5, 0.7],
     ];
     const baseline = [0.5, 0.6];
-    expect(computeForwardTransfer(sessions, baseline)).toBeCloseTo(-0.3, 4);
+    expect(computeForwardTransfer(a, baseline)).toBeCloseTo(-0.3, 4);
   });
 
-  it("returns 0 for empty sessions", () => {
+  it("returns 0 for empty matrix", () => {
     expect(computeForwardTransfer([], [])).toBe(0);
   });
 
@@ -59,64 +62,68 @@ describe("computeForwardTransfer", () => {
 });
 
 // --- computeForgetting ---
-// F = (1/(N-1)) * Σ_{j=0}^{N-2} (max(a[j][*]) - a[j][T])
-// Excludes last task; uses N-1 as denominator
+// F = (1/(N-1)) * Σ_{j=0}^{N-2} (max_k a[k][j] - a[N-1][j])
+// Reads columns, excludes last eval task. N-1 denominator.
 
 describe("computeForgetting", () => {
-  it("returns 0 for monotonically increasing sessions", () => {
-    const sessions = [
-      [0.5, 0.6, 0.7], // task 0: never drops → forgetting = 0
-      [0.0, 0.4, 0.5], // task 1: never drops → forgetting = 0
-      [0.0, 0.0, 0.8], // task 2: excluded (last task)
+  it("returns 0 when final performance matches peak (no degradation)", () => {
+    // Column 0 (task 0): [0.5, 0.6, 0.7] → max=0.7, final=0.7 → 0
+    // Column 1 (task 1): [0.0, 0.4, 0.5] → max=0.5, final=0.5 → 0
+    // Column 2 excluded (last eval task)
+    const a = [
+      [0.5, 0.0, 0.0],
+      [0.6, 0.4, 0.0],
+      [0.7, 0.5, 0.8],
     ];
-    expect(computeForgetting(sessions)).toBeCloseTo(0, 4);
+    expect(computeForgetting(a)).toBeCloseTo(0, 4);
   });
 
-  it("returns positive value for performance drops", () => {
-    // Task 0: peak 0.8, last 0.5 → forgetting = 0.3
-    // Task 1: peak 0.7, last 0.7 → forgetting = 0.0
-    // Task 2: excluded (last task)
+  it("returns positive value when final performance drops from peak", () => {
+    // Column 0 (task 0): [0.9, 0.8, 0.6] → max=0.9, final=0.6 → 0.3
+    // Column 1 (task 1): [0.0, 0.7, 0.7] → max=0.7, final=0.7 → 0.0
+    // Column 2 excluded (last eval task)
     // Mean = (0.3 + 0.0) / 2 = 0.15
-    const sessions = [
-      [0.6, 0.8, 0.5],
-      [0.0, 0.7, 0.7],
-      [0.0, 0.0, 0.9],
+    const a = [
+      [0.9, 0.0, 0.0],
+      [0.8, 0.7, 0.0],
+      [0.6, 0.7, 0.9],
     ];
-    expect(computeForgetting(sessions)).toBeCloseTo(0.15, 4);
+    expect(computeForgetting(a)).toBeCloseTo(0.15, 4);
   });
 
   it("returns 0 for single session (no forgetting possible)", () => {
-    const sessions = [[0.5], [0.7]];
-    expect(computeForgetting(sessions)).toBe(0);
+    const a = [[0.5], [0.7]];
+    expect(computeForgetting(a)).toBe(0);
   });
 
-  it("returns 0 for empty sessions", () => {
+  it("returns 0 for empty matrix", () => {
     expect(computeForgetting([])).toBe(0);
   });
 
-  it("returns 0 for N=1 (no tasks to forget)", () => {
-    const sessions = [[0.9, 0.7, 0.6]];
-    expect(computeForgetting(sessions)).toBe(0);
+  it("returns 0 for N=1 (single training stage)", () => {
+    const a = [[0.9, 0.7, 0.6]];
+    expect(computeForgetting(a)).toBe(0);
   });
 
-  it("handles constant performance (no forgetting)", () => {
-    const sessions = [
-      [0.5, 0.5, 0.5],
-      [0.7, 0.7, 0.7],
-      [0.0, 0.0, 0.8],
+  it("handles constant performance across training stages", () => {
+    // Column 0: [0.5, 0.5] → max=0.5, final=0.5 → 0
+    // Column 1 excluded
+    const a = [
+      [0.5, 0.0],
+      [0.5, 0.7],
     ];
-    expect(computeForgetting(sessions)).toBeCloseTo(0, 4);
+    expect(computeForgetting(a)).toBeCloseTo(0, 4);
   });
 
   it("computes correctly with two tasks", () => {
-    // Task 0: peak 0.9, last 0.6 → forgetting = 0.3
-    // Task 1: excluded (last task)
+    // Column 0 (task 0): [0.9, 0.6] → max=0.9, final=0.6 → 0.3
+    // Column 1 excluded (last eval task)
     // Mean = 0.3 / 1 = 0.3
-    const sessions = [
-      [0.9, 0.6],
-      [0.0, 0.8],
+    const a = [
+      [0.9, 0.0],
+      [0.6, 0.8],
     ];
-    expect(computeForgetting(sessions)).toBeCloseTo(0.3, 4);
+    expect(computeForgetting(a)).toBeCloseTo(0.3, 4);
   });
 });
 
@@ -124,60 +131,60 @@ describe("computeForgetting", () => {
 
 describe("computeCLFbeta", () => {
   it("computes harmonic mean of plasticity and stability", () => {
-    const sessions = [
+    const a = [
       [0.8, 0.7],
-      [0.0, 0.9],
+      [0.7, 0.9],
     ];
     const baseline = [0.5, 0.6];
-    const result = computeCLFbeta(sessions, baseline);
+    const result = computeCLFbeta(a, baseline);
     expect(result).toBeGreaterThan(0);
     expect(result).toBeLessThanOrEqual(1);
   });
 
   it("returns 0 when plasticity is 0", () => {
-    const sessions = [
+    const a = [
       [0.0, 0.5],
-      [0.0, 0.0],
+      [0.3, 0.0],
     ];
     const baseline = [0.5, 0.5];
-    expect(computeCLFbeta(sessions, baseline)).toBe(0);
+    expect(computeCLFbeta(a, baseline)).toBe(0);
   });
 
   it("returns 0 when stability is 0 (complete forgetting)", () => {
-    // Task 0: peak 1.0, drops to 0.0 → forgetting = 1.0
-    // Task 1: excluded (last task)
-    // stability = 1 - 1.0 = 0
-    const sessions = [
+    // Column 0: [1.0, 0.0] → max=1.0, final=0.0 → forgetting=1.0
+    // Column 1: excluded
+    // stability = max(0, 1 - 1.0) = 0
+    const a = [
       [1.0, 0.0],
       [0.0, 0.5],
     ];
     const baseline = [0.5, 0.5];
-    expect(computeCLFbeta(sessions, baseline)).toBe(0);
+    expect(computeCLFbeta(a, baseline)).toBe(0);
   });
 
   it("uses default beta=1 (equal weight)", () => {
-    const sessions = [
+    const a = [
       [0.8, 0.7],
-      [0.0, 0.9],
+      [0.7, 0.9],
     ];
     const baseline = [0.5, 0.6];
-    const defaultResult = computeCLFbeta(sessions, baseline);
-    const beta1Result = computeCLFbeta(sessions, baseline, 1);
+    const defaultResult = computeCLFbeta(a, baseline);
+    const beta1Result = computeCLFbeta(a, baseline, 1);
     expect(defaultResult).toBeCloseTo(beta1Result, 10);
   });
 
   it("accepts custom beta parameter", () => {
-    const sessions = [
+    const a = [
       [0.8, 0.7],
-      [0.0, 0.9],
+      [0.7, 0.9],
     ];
     const baseline = [0.5, 0.6];
-    const beta1 = computeCLFbeta(sessions, baseline, 1);
-    const beta2 = computeCLFbeta(sessions, baseline, 2);
+    const beta1 = computeCLFbeta(a, baseline, 1);
+    const beta2 = computeCLFbeta(a, baseline, 2);
     expect(beta1).not.toBeCloseTo(beta2, 4);
   });
 
-  it("returns 0 for empty sessions", () => {
+  it("returns 0 for empty matrix", () => {
     expect(computeCLFbeta([], [])).toBe(0);
   });
 });
@@ -188,34 +195,34 @@ describe("computeCLFbeta", () => {
 
 describe("computeCLScore", () => {
   it("computes composite score from ACC, FWT, and forgetting", () => {
-    const sessions = [
+    const a = [
       [0.8, 0.7],
-      [0.0, 0.9],
+      [0.7, 0.9],
     ];
     const baseline = [0.5, 0.6];
-    const score = computeCLScore(sessions, baseline);
+    const score = computeCLScore(a, baseline);
     expect(typeof score).toBe("number");
 
-    // ACC = mean of last row = (0.0 + 0.9) / 2 = 0.45
+    // ACC = mean of last row = (0.7 + 0.9) / 2 = 0.8
     // FWT = (a[0][1] - baseline[1]) / 1 = (0.7 - 0.6) / 1 = 0.1
-    // Forgetting: task 0 only (last excluded): max(0.8,0.7) - 0.7 = 0.1, mean = 0.1/1 = 0.1
-    // CL-Score = 0.45 + 0.1 - 0.1 = 0.45
-    expect(score).toBeCloseTo(0.45, 4);
+    // Forgetting: col 0 only: max(0.8,0.7)=0.8, final=0.7, f=0.1 → mean=0.1/1=0.1
+    // CL-Score = 0.8 + 0.1 - 0.1 = 0.8
+    expect(score).toBeCloseTo(0.8, 4);
   });
 
   it("is higher when ACM outperforms baseline in transfer", () => {
-    const sessions = [
+    const a = [
       [0.9, 0.9],
-      [0.0, 0.9],
+      [0.9, 0.9],
     ];
     const baselineLow = [0.3, 0.3];
     const baselineHigh = [0.8, 0.8];
-    const scoreLow = computeCLScore(sessions, baselineLow);
-    const scoreHigh = computeCLScore(sessions, baselineHigh);
+    const scoreLow = computeCLScore(a, baselineLow);
+    const scoreHigh = computeCLScore(a, baselineHigh);
     expect(scoreLow).toBeGreaterThan(scoreHigh);
   });
 
-  it("returns 0 for empty sessions", () => {
+  it("returns 0 for empty matrix", () => {
     expect(computeCLScore([], [])).toBe(0);
   });
 });
@@ -224,12 +231,12 @@ describe("computeCLScore", () => {
 
 describe("computeAllCLMetrics", () => {
   it("returns all metric fields", () => {
-    const acm = [
+    const a = [
       [0.8, 0.7],
-      [0.0, 0.9],
+      [0.7, 0.9],
     ];
     const baseline = [0.5, 0.6];
-    const result = computeAllCLMetrics(acm, baseline);
+    const result = computeAllCLMetrics(a, baseline);
 
     expect(result).toHaveProperty("forward_transfer");
     expect(result).toHaveProperty("forgetting");
@@ -240,61 +247,68 @@ describe("computeAllCLMetrics", () => {
   });
 
   it("computes consistent values across individual functions", () => {
-    const acm = [
+    const a = [
       [0.8, 0.7],
-      [0.0, 0.9],
+      [0.7, 0.9],
     ];
     const baseline = [0.5, 0.6];
-    const result = computeAllCLMetrics(acm, baseline);
+    const result = computeAllCLMetrics(a, baseline);
 
-    // stability = 1 - forgetting
-    expect(result.stability).toBeCloseTo(1 - result.forgetting, 10);
+    // stability = max(0, 1 - forgetting)
+    expect(result.stability).toBeCloseTo(Math.max(0, 1 - result.forgetting), 10);
 
     // forward_transfer matches standalone
-    expect(result.forward_transfer).toBeCloseTo(computeForwardTransfer(acm, baseline), 10);
+    expect(result.forward_transfer).toBeCloseTo(computeForwardTransfer(a, baseline), 10);
 
     // forgetting matches standalone
-    expect(result.forgetting).toBeCloseTo(computeForgetting(acm), 10);
+    expect(result.forgetting).toBeCloseTo(computeForgetting(a), 10);
 
     // cl_f_beta matches standalone
-    expect(result.cl_f_beta).toBeCloseTo(computeCLFbeta(acm, baseline), 10);
+    expect(result.cl_f_beta).toBeCloseTo(computeCLFbeta(a, baseline), 10);
   });
 
   it("handles perfect scenario (no forgetting, high performance)", () => {
-    const acm = [
+    // Column 0: [1.0, 1.0] → max=1.0, final=1.0 → 0 forgetting
+    // Column 1: excluded
+    const a = [
+      [1.0, 0.5],
       [1.0, 1.0],
-      [0.0, 1.0],
     ];
     const baseline = [0.5, 0.5];
-    const result = computeAllCLMetrics(acm, baseline);
+    const result = computeAllCLMetrics(a, baseline);
 
     expect(result.forgetting).toBe(0);
     expect(result.stability).toBe(1);
     expect(result.plasticity).toBeCloseTo(1.0, 4);
-    // FWT = (a[0][1] - baseline[1]) / 1 = (1.0 - 0.5) / 1 = 0.5
-    expect(result.forward_transfer).toBeCloseTo(0.5, 4);
+    // FWT = (a[0][1] - baseline[1]) / 1 = (0.5 - 0.5) / 1 = 0
+    expect(result.forward_transfer).toBeCloseTo(0, 4);
   });
 
   it("handles 3x3 matrix with mixed performance", () => {
-    const acm = [
-      [0.9, 0.8, 0.6], // task 0: peaks at 0.9, drops to 0.6
-      [0.0, 0.7, 0.7], // task 1: stable at 0.7
-      [0.0, 0.0, 0.8], // task 2: introduced last
+    // Matrix: rows = training stage, cols = eval task
+    const a = [
+      [0.9, 0.3, 0.2], // trained through task 0
+      [0.7, 0.8, 0.4], // trained through task 1
+      [0.6, 0.7, 0.8], // trained through task 2 (final)
     ];
     const baseline = [0.4, 0.3, 0.3];
-    const result = computeAllCLMetrics(acm, baseline);
+    const result = computeAllCLMetrics(a, baseline);
 
-    // Plasticity = mean diagonal = (0.9 + 0.7 + 0.8) / 3 = 0.8
-    expect(result.plasticity).toBeCloseTo(0.8, 4);
+    // Plasticity = mean diagonal = (0.9 + 0.8 + 0.8) / 3 ≈ 0.8333
+    expect(result.plasticity).toBeCloseTo(0.8333, 3);
 
-    // Forgetting (exclude task 2):
-    // task 0: max=0.9, last=0.6, f=0.3
-    // task 1: max=0.7, last=0.7, f=0.0
-    // mean = 0.3 / 2 = 0.15
-    expect(result.forgetting).toBeCloseTo(0.15, 4);
+    // Forgetting (cols 0,1 only, exclude col 2):
+    // col 0: max(0.9,0.7,0.6)=0.9, final=0.6, f=0.3
+    // col 1: max(0.3,0.8,0.7)=0.8, final=0.7, f=0.1
+    // mean = (0.3 + 0.1) / 2 = 0.2
+    expect(result.forgetting).toBeCloseTo(0.2, 4);
 
     // FWT: (a[0][1]-baseline[1] + a[1][2]-baseline[2]) / 2
-    // = (0.8-0.3 + 0.7-0.3) / 2 = (0.5 + 0.4) / 2 = 0.45
-    expect(result.forward_transfer).toBeCloseTo(0.45, 4);
+    // = (0.3-0.3 + 0.4-0.3) / 2 = (0.0 + 0.1) / 2 = 0.05
+    expect(result.forward_transfer).toBeCloseTo(0.05, 4);
+
+    // ACC = mean of last row = (0.6 + 0.7 + 0.8) / 3 = 0.7
+    // CL-Score = 0.7 + 0.05 - 0.2 = 0.55
+    expect(result.cl_score).toBeCloseTo(0.55, 4);
   });
 });

--- a/experiments/benchmarks/__tests__/cl-metrics.test.ts
+++ b/experiments/benchmarks/__tests__/cl-metrics.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for CL (Continual Learning) Metrics — Issue #106 (#95-A)
+ *
+ * Pure function tests based on SWE-Bench-CL (arXiv:2507.00014) Section 7 metrics.
+ * No mocks needed — all functions are pure.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  computeForwardTransfer,
+  computeForgetting,
+  computeCLFbeta,
+  computeCLScore,
+  computeAllCLMetrics,
+} from "../cl-metrics.js";
+
+// --- computeForwardTransfer ---
+// FT = (1/(N-1)) * Σ_{i=0}^{N-2} (a[i][i+1] - baseline[i+1])
+// Uses superdiagonal: after training on task i, performance on task i+1
+
+describe("computeForwardTransfer", () => {
+  it("returns positive value when ACM transfers to next task better than baseline", () => {
+    // sessions[0][1] = 0.7 (task 0 trained, eval task 1) vs baseline[1] = 0.4
+    // sessions[1][2] = 0.8 (task 1 trained, eval task 2) vs baseline[2] = 0.3
+    // FWT = ((0.7-0.4) + (0.8-0.3)) / 2 = (0.3 + 0.5) / 2 = 0.4
+    const sessions = [
+      [0.8, 0.7, 0.6],
+      [0.0, 0.9, 0.8],
+      [0.0, 0.0, 0.7],
+    ];
+    const baseline = [0.5, 0.4, 0.3];
+    expect(computeForwardTransfer(sessions, baseline)).toBeCloseTo(0.4, 4);
+  });
+
+  it("returns 0 when superdiagonal equals baseline", () => {
+    const sessions = [
+      [0.8, 0.6], // a[0][1] = 0.6 == baseline[1]
+      [0.0, 0.9],
+    ];
+    const baseline = [0.5, 0.6];
+    expect(computeForwardTransfer(sessions, baseline)).toBeCloseTo(0, 4);
+  });
+
+  it("returns negative when baseline outperforms superdiagonal", () => {
+    const sessions = [
+      [0.8, 0.3], // a[0][1] = 0.3 < baseline[1] = 0.6
+      [0.0, 0.7],
+    ];
+    const baseline = [0.5, 0.6];
+    expect(computeForwardTransfer(sessions, baseline)).toBeCloseTo(-0.3, 4);
+  });
+
+  it("returns 0 for empty sessions", () => {
+    expect(computeForwardTransfer([], [])).toBe(0);
+  });
+
+  it("returns 0 for N=1 (no transfer possible)", () => {
+    expect(computeForwardTransfer([[0.8]], [0.5])).toBe(0);
+  });
+});
+
+// --- computeForgetting ---
+// F = (1/(N-1)) * Σ_{j=0}^{N-2} (max(a[j][*]) - a[j][T])
+// Excludes last task; uses N-1 as denominator
+
+describe("computeForgetting", () => {
+  it("returns 0 for monotonically increasing sessions", () => {
+    const sessions = [
+      [0.5, 0.6, 0.7], // task 0: never drops → forgetting = 0
+      [0.0, 0.4, 0.5], // task 1: never drops → forgetting = 0
+      [0.0, 0.0, 0.8], // task 2: excluded (last task)
+    ];
+    expect(computeForgetting(sessions)).toBeCloseTo(0, 4);
+  });
+
+  it("returns positive value for performance drops", () => {
+    // Task 0: peak 0.8, last 0.5 → forgetting = 0.3
+    // Task 1: peak 0.7, last 0.7 → forgetting = 0.0
+    // Task 2: excluded (last task)
+    // Mean = (0.3 + 0.0) / 2 = 0.15
+    const sessions = [
+      [0.6, 0.8, 0.5],
+      [0.0, 0.7, 0.7],
+      [0.0, 0.0, 0.9],
+    ];
+    expect(computeForgetting(sessions)).toBeCloseTo(0.15, 4);
+  });
+
+  it("returns 0 for single session (no forgetting possible)", () => {
+    const sessions = [[0.5], [0.7]];
+    expect(computeForgetting(sessions)).toBe(0);
+  });
+
+  it("returns 0 for empty sessions", () => {
+    expect(computeForgetting([])).toBe(0);
+  });
+
+  it("returns 0 for N=1 (no tasks to forget)", () => {
+    const sessions = [[0.9, 0.7, 0.6]];
+    expect(computeForgetting(sessions)).toBe(0);
+  });
+
+  it("handles constant performance (no forgetting)", () => {
+    const sessions = [
+      [0.5, 0.5, 0.5],
+      [0.7, 0.7, 0.7],
+      [0.0, 0.0, 0.8],
+    ];
+    expect(computeForgetting(sessions)).toBeCloseTo(0, 4);
+  });
+
+  it("computes correctly with two tasks", () => {
+    // Task 0: peak 0.9, last 0.6 → forgetting = 0.3
+    // Task 1: excluded (last task)
+    // Mean = 0.3 / 1 = 0.3
+    const sessions = [
+      [0.9, 0.6],
+      [0.0, 0.8],
+    ];
+    expect(computeForgetting(sessions)).toBeCloseTo(0.3, 4);
+  });
+});
+
+// --- computeCLFbeta ---
+
+describe("computeCLFbeta", () => {
+  it("computes harmonic mean of plasticity and stability", () => {
+    const sessions = [
+      [0.8, 0.7],
+      [0.0, 0.9],
+    ];
+    const baseline = [0.5, 0.6];
+    const result = computeCLFbeta(sessions, baseline);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThanOrEqual(1);
+  });
+
+  it("returns 0 when plasticity is 0", () => {
+    const sessions = [
+      [0.0, 0.5],
+      [0.0, 0.0],
+    ];
+    const baseline = [0.5, 0.5];
+    expect(computeCLFbeta(sessions, baseline)).toBe(0);
+  });
+
+  it("returns 0 when stability is 0 (complete forgetting)", () => {
+    // Task 0: peak 1.0, drops to 0.0 → forgetting = 1.0
+    // Task 1: excluded (last task)
+    // stability = 1 - 1.0 = 0
+    const sessions = [
+      [1.0, 0.0],
+      [0.0, 0.5],
+    ];
+    const baseline = [0.5, 0.5];
+    expect(computeCLFbeta(sessions, baseline)).toBe(0);
+  });
+
+  it("uses default beta=1 (equal weight)", () => {
+    const sessions = [
+      [0.8, 0.7],
+      [0.0, 0.9],
+    ];
+    const baseline = [0.5, 0.6];
+    const defaultResult = computeCLFbeta(sessions, baseline);
+    const beta1Result = computeCLFbeta(sessions, baseline, 1);
+    expect(defaultResult).toBeCloseTo(beta1Result, 10);
+  });
+
+  it("accepts custom beta parameter", () => {
+    const sessions = [
+      [0.8, 0.7],
+      [0.0, 0.9],
+    ];
+    const baseline = [0.5, 0.6];
+    const beta1 = computeCLFbeta(sessions, baseline, 1);
+    const beta2 = computeCLFbeta(sessions, baseline, 2);
+    expect(beta1).not.toBeCloseTo(beta2, 4);
+  });
+
+  it("returns 0 for empty sessions", () => {
+    expect(computeCLFbeta([], [])).toBe(0);
+  });
+});
+
+// --- computeCLScore ---
+// CL-Score = ACC + FWT - Forgetting
+// ACC = mean of last row (final accuracy after all training)
+
+describe("computeCLScore", () => {
+  it("computes composite score from ACC, FWT, and forgetting", () => {
+    const sessions = [
+      [0.8, 0.7],
+      [0.0, 0.9],
+    ];
+    const baseline = [0.5, 0.6];
+    const score = computeCLScore(sessions, baseline);
+    expect(typeof score).toBe("number");
+
+    // ACC = mean of last row = (0.0 + 0.9) / 2 = 0.45
+    // FWT = (a[0][1] - baseline[1]) / 1 = (0.7 - 0.6) / 1 = 0.1
+    // Forgetting: task 0 only (last excluded): max(0.8,0.7) - 0.7 = 0.1, mean = 0.1/1 = 0.1
+    // CL-Score = 0.45 + 0.1 - 0.1 = 0.45
+    expect(score).toBeCloseTo(0.45, 4);
+  });
+
+  it("is higher when ACM outperforms baseline in transfer", () => {
+    const sessions = [
+      [0.9, 0.9],
+      [0.0, 0.9],
+    ];
+    const baselineLow = [0.3, 0.3];
+    const baselineHigh = [0.8, 0.8];
+    const scoreLow = computeCLScore(sessions, baselineLow);
+    const scoreHigh = computeCLScore(sessions, baselineHigh);
+    expect(scoreLow).toBeGreaterThan(scoreHigh);
+  });
+
+  it("returns 0 for empty sessions", () => {
+    expect(computeCLScore([], [])).toBe(0);
+  });
+});
+
+// --- computeAllCLMetrics ---
+
+describe("computeAllCLMetrics", () => {
+  it("returns all metric fields", () => {
+    const acm = [
+      [0.8, 0.7],
+      [0.0, 0.9],
+    ];
+    const baseline = [0.5, 0.6];
+    const result = computeAllCLMetrics(acm, baseline);
+
+    expect(result).toHaveProperty("forward_transfer");
+    expect(result).toHaveProperty("forgetting");
+    expect(result).toHaveProperty("cl_f_beta");
+    expect(result).toHaveProperty("cl_score");
+    expect(result).toHaveProperty("plasticity");
+    expect(result).toHaveProperty("stability");
+  });
+
+  it("computes consistent values across individual functions", () => {
+    const acm = [
+      [0.8, 0.7],
+      [0.0, 0.9],
+    ];
+    const baseline = [0.5, 0.6];
+    const result = computeAllCLMetrics(acm, baseline);
+
+    // stability = 1 - forgetting
+    expect(result.stability).toBeCloseTo(1 - result.forgetting, 10);
+
+    // forward_transfer matches standalone
+    expect(result.forward_transfer).toBeCloseTo(computeForwardTransfer(acm, baseline), 10);
+
+    // forgetting matches standalone
+    expect(result.forgetting).toBeCloseTo(computeForgetting(acm), 10);
+
+    // cl_f_beta matches standalone
+    expect(result.cl_f_beta).toBeCloseTo(computeCLFbeta(acm, baseline), 10);
+  });
+
+  it("handles perfect scenario (no forgetting, high performance)", () => {
+    const acm = [
+      [1.0, 1.0],
+      [0.0, 1.0],
+    ];
+    const baseline = [0.5, 0.5];
+    const result = computeAllCLMetrics(acm, baseline);
+
+    expect(result.forgetting).toBe(0);
+    expect(result.stability).toBe(1);
+    expect(result.plasticity).toBeCloseTo(1.0, 4);
+    // FWT = (a[0][1] - baseline[1]) / 1 = (1.0 - 0.5) / 1 = 0.5
+    expect(result.forward_transfer).toBeCloseTo(0.5, 4);
+  });
+
+  it("handles 3x3 matrix with mixed performance", () => {
+    const acm = [
+      [0.9, 0.8, 0.6], // task 0: peaks at 0.9, drops to 0.6
+      [0.0, 0.7, 0.7], // task 1: stable at 0.7
+      [0.0, 0.0, 0.8], // task 2: introduced last
+    ];
+    const baseline = [0.4, 0.3, 0.3];
+    const result = computeAllCLMetrics(acm, baseline);
+
+    // Plasticity = mean diagonal = (0.9 + 0.7 + 0.8) / 3 = 0.8
+    expect(result.plasticity).toBeCloseTo(0.8, 4);
+
+    // Forgetting (exclude task 2):
+    // task 0: max=0.9, last=0.6, f=0.3
+    // task 1: max=0.7, last=0.7, f=0.0
+    // mean = 0.3 / 2 = 0.15
+    expect(result.forgetting).toBeCloseTo(0.15, 4);
+
+    // FWT: (a[0][1]-baseline[1] + a[1][2]-baseline[2]) / 2
+    // = (0.8-0.3 + 0.7-0.3) / 2 = (0.5 + 0.4) / 2 = 0.45
+    expect(result.forward_transfer).toBeCloseTo(0.45, 4);
+  });
+});

--- a/experiments/benchmarks/cl-metrics.ts
+++ b/experiments/benchmarks/cl-metrics.ts
@@ -4,10 +4,14 @@
  * Pure functions implementing CL metrics from SWE-Bench-CL (arXiv:2507.00014 Section 7).
  * No I/O, no side effects.
  *
- * Terminology:
- *   sessions[i][j] = performance of task i after training on session j
- *   The "performance matrix" is tasks × sessions (rows = tasks, columns = sessions)
- *   baseline[i] = performance of task i without any memory/experience
+ * Matrix convention (matches paper):
+ *   a[i][j] = performance on task j after training through task i
+ *   Rows = training stage (which task was last trained on)
+ *   Columns = evaluation task
+ *   a[i][i] = diagonal = performance on task i when first introduced (plasticity)
+ *   a[i][i+1] = superdiagonal = performance on next task after training on current
+ *   a[N-1][j] = last row = final accuracy on task j after all training
+ *   baseline[j] = performance on task j without any memory/experience
  *
  * Simplifications vs. full paper:
  *   CL-Score uses ACC + FWT - Forgetting (BWT/AULC/TUE omitted, equivalent to all λ=1 and
@@ -30,20 +34,20 @@ export interface CLMetricsResult {
  * Forward Transfer: measures how past experience improves performance on new tasks.
  * FT = (1/(N-1)) * Σ_{i=0}^{N-2} (a[i][i+1] - baseline[i+1])
  *
- * Uses the superdiagonal of the performance matrix: after training on task i,
- * how well does the agent perform on task i+1 compared to baseline?
+ * Uses the superdiagonal: after training on task i, performance on task i+1
+ * compared to baseline.
  *
- * @param sessions - Performance matrix: sessions[task][session]
+ * @param a - Performance matrix a[trained_on][eval_task]
  * @param baseline - Baseline performance per task (no memory condition)
  * @returns Mean forward transfer score. Returns 0 for N <= 1.
  */
-export function computeForwardTransfer(sessions: number[][], baseline: number[]): number {
-  const N = sessions.length;
+export function computeForwardTransfer(a: number[][], baseline: number[]): number {
+  const N = a.length;
   if (N <= 1) return 0;
 
   let sum = 0;
   for (let i = 0; i < N - 1; i++) {
-    const a_i_next = sessions[i][i + 1] ?? 0;
+    const a_i_next = a[i][i + 1] ?? 0;
     sum += a_i_next - baseline[i + 1];
   }
   return sum / (N - 1);
@@ -51,45 +55,49 @@ export function computeForwardTransfer(sessions: number[][], baseline: number[])
 
 /**
  * Forgetting: measures how previously learned knowledge degrades over time.
- * F = (1/(N-1)) * Σ_{j=0}^{N-2} (max_{k<=j} a[j][k] - a[j][T])
+ * F = (1/(N-1)) * Σ_{j=0}^{N-2} (max_{k: 0<=k<=N-1} a[k][j] - a[N-1][j])
  *
- * Excludes the last task (no subsequent sessions to forget).
- * Max is taken over sessions up to and including the task's introduction.
+ * For each eval task j (excluding the last), computes the gap between
+ * peak performance (across all training stages) and final performance
+ * (after training on all tasks).
  *
- * @param sessions - Performance matrix: sessions[task][session]
+ * @param a - Performance matrix a[trained_on][eval_task]
  * @returns Mean forgetting score (0 = no forgetting). Returns 0 for N <= 1.
  */
-export function computeForgetting(sessions: number[][]): number {
-  const N = sessions.length;
+export function computeForgetting(a: number[][]): number {
+  const N = a.length;
   if (N <= 1) return 0;
 
-  const numSessions = sessions[0]?.length ?? 0;
-  if (numSessions <= 1) return 0;
+  const numTasks = a[0]?.length ?? 0;
+  if (numTasks <= 1) return 0;
 
   let totalForgetting = 0;
-  // Sum over tasks j = 0..N-2 (exclude last task per paper)
-  for (let j = 0; j < N - 1; j++) {
-    const taskPerf = sessions[j];
-    const lastPerf = taskPerf[taskPerf.length - 1];
-    const maxPerf = Math.max(...taskPerf);
-    totalForgetting += Math.max(0, maxPerf - lastPerf);
+  // Sum over eval tasks j = 0..N-2 (exclude last task per paper)
+  for (let j = 0; j < numTasks - 1; j++) {
+    // Read column j: performance on task j across all training stages
+    let maxPerf = -Infinity;
+    for (let k = 0; k < N; k++) {
+      maxPerf = Math.max(maxPerf, a[k][j] ?? 0);
+    }
+    const finalPerf = a[N - 1][j] ?? 0;
+    totalForgetting += Math.max(0, maxPerf - finalPerf);
   }
 
-  return totalForgetting / (N - 1);
+  return totalForgetting / (numTasks - 1);
 }
 
 /**
- * Plasticity: mean of diagonal elements (sessions[i][i]).
- * Measures immediate learning ability on each task.
+ * Plasticity: mean of diagonal elements a[i][i].
+ * Measures immediate learning ability on each task when first introduced.
  */
-function computePlasticity(sessions: number[][]): number {
-  if (sessions.length === 0) return 0;
+function computePlasticity(a: number[][]): number {
+  if (a.length === 0) return 0;
 
   let sum = 0;
   let count = 0;
-  for (let i = 0; i < sessions.length; i++) {
-    if (i < sessions[i].length) {
-      sum += sessions[i][i];
+  for (let i = 0; i < a.length; i++) {
+    if (i < a[i].length) {
+      sum += a[i][i];
       count++;
     }
   }
@@ -101,9 +109,9 @@ function computePlasticity(sessions: number[][]): number {
  * Measures final retained accuracy across all tasks after all training.
  * ACC = (1/N) * Σ_{j=0}^{N-1} a[N-1][j]
  */
-function computeACC(sessions: number[][]): number {
-  if (sessions.length === 0) return 0;
-  const lastRow = sessions[sessions.length - 1];
+function computeACC(a: number[][]): number {
+  if (a.length === 0) return 0;
+  const lastRow = a[a.length - 1];
   if (lastRow.length === 0) return 0;
   return lastRow.reduce((s, v) => s + v, 0) / lastRow.length;
 }
@@ -111,25 +119,21 @@ function computeACC(sessions: number[][]): number {
 /**
  * CL-Fβ: harmonic mean of CL-Plasticity and CL-Stability.
  * CL-Fβ = (1 + β²) * P * S / (β² * P + S)
- * where P = plasticity, S = 1 - forgetting
+ * where P = plasticity, S = max(0, 1 - forgetting)
  *
- * @param sessions - Performance matrix: sessions[task][session]
+ * @param a - Performance matrix a[trained_on][eval_task]
  * @param _baseline - Baseline (unused in Fβ, kept for API consistency)
  * @param beta - Weight parameter (default 1 = equal weight)
  * @returns CL-Fβ score
  */
-export function computeCLFbeta(
-  sessions: number[][],
-  _baseline: number[],
-  beta: number = 1
-): number {
-  if (sessions.length === 0) return 0;
+export function computeCLFbeta(a: number[][], _baseline: number[], beta: number = 1): number {
+  if (a.length === 0) return 0;
 
-  const plasticity = computePlasticity(sessions);
-  const forgetting = computeForgetting(sessions);
-  const stability = 1 - forgetting;
+  const plasticity = computePlasticity(a);
+  const forgetting = computeForgetting(a);
+  const stability = Math.max(0, 1 - forgetting);
 
-  if (plasticity === 0 || stability <= 0) return 0;
+  if (plasticity === 0 || stability === 0) return 0;
 
   const betaSq = beta * beta;
   return ((1 + betaSq) * plasticity * stability) / (betaSq * plasticity + stability);
@@ -141,16 +145,16 @@ export function computeCLFbeta(
  *
  * Simplified from the paper's full formula (BWT, AULC, TUE terms omitted).
  *
- * @param sessions - Performance matrix: sessions[task][session]
+ * @param a - Performance matrix a[trained_on][eval_task]
  * @param baseline - Baseline performance per task
  * @returns Composite CL score
  */
-export function computeCLScore(sessions: number[][], baseline: number[]): number {
-  if (sessions.length === 0) return 0;
+export function computeCLScore(a: number[][], baseline: number[]): number {
+  if (a.length === 0) return 0;
 
-  const acc = computeACC(sessions);
-  const fwt = computeForwardTransfer(sessions, baseline);
-  const forgetting = computeForgetting(sessions);
+  const acc = computeACC(a);
+  const fwt = computeForwardTransfer(a, baseline);
+  const forgetting = computeForgetting(a);
 
   return acc + fwt - forgetting;
 }
@@ -158,17 +162,17 @@ export function computeCLScore(sessions: number[][], baseline: number[]): number
 /**
  * Compute all CL metrics in one call.
  *
- * @param acm - Performance matrix for ACM condition: acm[task][session]
+ * @param a - Performance matrix a[trained_on][eval_task]
  * @param baseline - Baseline performance per task (no memory condition)
  * @returns All CL metrics
  */
-export function computeAllCLMetrics(acm: number[][], baseline: number[]): CLMetricsResult {
-  const forward_transfer = computeForwardTransfer(acm, baseline);
-  const forgetting = computeForgetting(acm);
-  const plasticity = computePlasticity(acm);
-  const stability = 1 - forgetting;
-  const cl_f_beta = computeCLFbeta(acm, baseline);
-  const cl_score = computeCLScore(acm, baseline);
+export function computeAllCLMetrics(a: number[][], baseline: number[]): CLMetricsResult {
+  const forward_transfer = computeForwardTransfer(a, baseline);
+  const forgetting = computeForgetting(a);
+  const plasticity = computePlasticity(a);
+  const stability = Math.max(0, 1 - forgetting);
+  const cl_f_beta = computeCLFbeta(a, baseline);
+  const cl_score = computeCLScore(a, baseline);
 
   return {
     forward_transfer,

--- a/experiments/benchmarks/cl-metrics.ts
+++ b/experiments/benchmarks/cl-metrics.ts
@@ -1,0 +1,181 @@
+/**
+ * Continual Learning Metrics — Issue #106 (#95-A)
+ *
+ * Pure functions implementing CL metrics from SWE-Bench-CL (arXiv:2507.00014 Section 7).
+ * No I/O, no side effects.
+ *
+ * Terminology:
+ *   sessions[i][j] = performance of task i after training on session j
+ *   The "performance matrix" is tasks × sessions (rows = tasks, columns = sessions)
+ *   baseline[i] = performance of task i without any memory/experience
+ *
+ * Simplifications vs. full paper:
+ *   CL-Score uses ACC + FWT - Forgetting (BWT/AULC/TUE omitted, equivalent to all λ=1 and
+ *   those terms = 0). This matches the paper's primary evaluation axis.
+ */
+
+/**
+ * Result type for computeAllCLMetrics
+ */
+export interface CLMetricsResult {
+  forward_transfer: number;
+  forgetting: number;
+  plasticity: number;
+  stability: number;
+  cl_f_beta: number;
+  cl_score: number;
+}
+
+/**
+ * Forward Transfer: measures how past experience improves performance on new tasks.
+ * FT = (1/(N-1)) * Σ_{i=0}^{N-2} (a[i][i+1] - baseline[i+1])
+ *
+ * Uses the superdiagonal of the performance matrix: after training on task i,
+ * how well does the agent perform on task i+1 compared to baseline?
+ *
+ * @param sessions - Performance matrix: sessions[task][session]
+ * @param baseline - Baseline performance per task (no memory condition)
+ * @returns Mean forward transfer score. Returns 0 for N <= 1.
+ */
+export function computeForwardTransfer(sessions: number[][], baseline: number[]): number {
+  const N = sessions.length;
+  if (N <= 1) return 0;
+
+  let sum = 0;
+  for (let i = 0; i < N - 1; i++) {
+    const a_i_next = sessions[i][i + 1] ?? 0;
+    sum += a_i_next - baseline[i + 1];
+  }
+  return sum / (N - 1);
+}
+
+/**
+ * Forgetting: measures how previously learned knowledge degrades over time.
+ * F = (1/(N-1)) * Σ_{j=0}^{N-2} (max_{k<=j} a[j][k] - a[j][T])
+ *
+ * Excludes the last task (no subsequent sessions to forget).
+ * Max is taken over sessions up to and including the task's introduction.
+ *
+ * @param sessions - Performance matrix: sessions[task][session]
+ * @returns Mean forgetting score (0 = no forgetting). Returns 0 for N <= 1.
+ */
+export function computeForgetting(sessions: number[][]): number {
+  const N = sessions.length;
+  if (N <= 1) return 0;
+
+  const numSessions = sessions[0]?.length ?? 0;
+  if (numSessions <= 1) return 0;
+
+  let totalForgetting = 0;
+  // Sum over tasks j = 0..N-2 (exclude last task per paper)
+  for (let j = 0; j < N - 1; j++) {
+    const taskPerf = sessions[j];
+    const lastPerf = taskPerf[taskPerf.length - 1];
+    const maxPerf = Math.max(...taskPerf);
+    totalForgetting += Math.max(0, maxPerf - lastPerf);
+  }
+
+  return totalForgetting / (N - 1);
+}
+
+/**
+ * Plasticity: mean of diagonal elements (sessions[i][i]).
+ * Measures immediate learning ability on each task.
+ */
+function computePlasticity(sessions: number[][]): number {
+  if (sessions.length === 0) return 0;
+
+  let sum = 0;
+  let count = 0;
+  for (let i = 0; i < sessions.length; i++) {
+    if (i < sessions[i].length) {
+      sum += sessions[i][i];
+      count++;
+    }
+  }
+  return count > 0 ? sum / count : 0;
+}
+
+/**
+ * ACC: mean of the last row of the performance matrix.
+ * Measures final retained accuracy across all tasks after all training.
+ * ACC = (1/N) * Σ_{j=0}^{N-1} a[N-1][j]
+ */
+function computeACC(sessions: number[][]): number {
+  if (sessions.length === 0) return 0;
+  const lastRow = sessions[sessions.length - 1];
+  if (lastRow.length === 0) return 0;
+  return lastRow.reduce((s, v) => s + v, 0) / lastRow.length;
+}
+
+/**
+ * CL-Fβ: harmonic mean of CL-Plasticity and CL-Stability.
+ * CL-Fβ = (1 + β²) * P * S / (β² * P + S)
+ * where P = plasticity, S = 1 - forgetting
+ *
+ * @param sessions - Performance matrix: sessions[task][session]
+ * @param _baseline - Baseline (unused in Fβ, kept for API consistency)
+ * @param beta - Weight parameter (default 1 = equal weight)
+ * @returns CL-Fβ score
+ */
+export function computeCLFbeta(
+  sessions: number[][],
+  _baseline: number[],
+  beta: number = 1
+): number {
+  if (sessions.length === 0) return 0;
+
+  const plasticity = computePlasticity(sessions);
+  const forgetting = computeForgetting(sessions);
+  const stability = 1 - forgetting;
+
+  if (plasticity === 0 || stability <= 0) return 0;
+
+  const betaSq = beta * beta;
+  return ((1 + betaSq) * plasticity * stability) / (betaSq * plasticity + stability);
+}
+
+/**
+ * CL-Score: composite score combining accuracy and forward transfer.
+ * CL-Score = ACC + FWT - Forgetting
+ *
+ * Simplified from the paper's full formula (BWT, AULC, TUE terms omitted).
+ *
+ * @param sessions - Performance matrix: sessions[task][session]
+ * @param baseline - Baseline performance per task
+ * @returns Composite CL score
+ */
+export function computeCLScore(sessions: number[][], baseline: number[]): number {
+  if (sessions.length === 0) return 0;
+
+  const acc = computeACC(sessions);
+  const fwt = computeForwardTransfer(sessions, baseline);
+  const forgetting = computeForgetting(sessions);
+
+  return acc + fwt - forgetting;
+}
+
+/**
+ * Compute all CL metrics in one call.
+ *
+ * @param acm - Performance matrix for ACM condition: acm[task][session]
+ * @param baseline - Baseline performance per task (no memory condition)
+ * @returns All CL metrics
+ */
+export function computeAllCLMetrics(acm: number[][], baseline: number[]): CLMetricsResult {
+  const forward_transfer = computeForwardTransfer(acm, baseline);
+  const forgetting = computeForgetting(acm);
+  const plasticity = computePlasticity(acm);
+  const stability = 1 - forgetting;
+  const cl_f_beta = computeCLFbeta(acm, baseline);
+  const cl_score = computeCLScore(acm, baseline);
+
+  return {
+    forward_transfer,
+    forgetting,
+    plasticity,
+    stability,
+    cl_f_beta,
+    cl_score,
+  };
+}

--- a/experiments/benchmarks/cl-metrics.ts
+++ b/experiments/benchmarks/cl-metrics.ts
@@ -8,6 +8,7 @@
  *   a[i][j] = performance on task j after training through task i
  *   Rows = training stage (which task was last trained on)
  *   Columns = evaluation task
+ *   Matrix MUST be square (N × N). Non-square input throws RangeError.
  *   a[i][i] = diagonal = performance on task i when first introduced (plasticity)
  *   a[i][i+1] = superdiagonal = performance on next task after training on current
  *   a[N-1][j] = last row = final accuracy on task j after all training
@@ -30,6 +31,18 @@ export interface CLMetricsResult {
   cl_score: number;
 }
 
+/** Validate that a is a square N×N matrix with all finite values. */
+function assertSquareMatrix(a: number[][], caller: string): void {
+  const N = a.length;
+  for (let i = 0; i < N; i++) {
+    if (a[i].length !== N) {
+      throw new RangeError(
+        `${caller}: matrix must be square (row ${i} has ${a[i].length} cols, expected ${N})`
+      );
+    }
+  }
+}
+
 /**
  * Forward Transfer: measures how past experience improves performance on new tasks.
  * FT = (1/(N-1)) * Σ_{i=0}^{N-2} (a[i][i+1] - baseline[i+1])
@@ -37,18 +50,24 @@ export interface CLMetricsResult {
  * Uses the superdiagonal: after training on task i, performance on task i+1
  * compared to baseline.
  *
- * @param a - Performance matrix a[trained_on][eval_task]
- * @param baseline - Baseline performance per task (no memory condition)
+ * @param a - Square performance matrix a[trained_on][eval_task]
+ * @param baseline - Baseline performance per task (length must be >= N)
  * @returns Mean forward transfer score. Returns 0 for N <= 1.
  */
 export function computeForwardTransfer(a: number[][], baseline: number[]): number {
   const N = a.length;
   if (N <= 1) return 0;
+  assertSquareMatrix(a, "computeForwardTransfer");
+
+  if (baseline.length < N) {
+    throw new RangeError(
+      `computeForwardTransfer: baseline length ${baseline.length} must be >= matrix size ${N}`
+    );
+  }
 
   let sum = 0;
   for (let i = 0; i < N - 1; i++) {
-    const a_i_next = a[i][i + 1] ?? 0;
-    sum += a_i_next - baseline[i + 1];
+    sum += a[i][i + 1] - baseline[i + 1];
   }
   return sum / (N - 1);
 }
@@ -61,29 +80,26 @@ export function computeForwardTransfer(a: number[][], baseline: number[]): numbe
  * peak performance (across all training stages) and final performance
  * (after training on all tasks).
  *
- * @param a - Performance matrix a[trained_on][eval_task]
+ * @param a - Square performance matrix a[trained_on][eval_task]
  * @returns Mean forgetting score (0 = no forgetting). Returns 0 for N <= 1.
  */
 export function computeForgetting(a: number[][]): number {
   const N = a.length;
   if (N <= 1) return 0;
-
-  const numTasks = a[0]?.length ?? 0;
-  if (numTasks <= 1) return 0;
+  assertSquareMatrix(a, "computeForgetting");
 
   let totalForgetting = 0;
-  // Sum over eval tasks j = 0..N-2 (exclude last task per paper)
-  for (let j = 0; j < numTasks - 1; j++) {
-    // Read column j: performance on task j across all training stages
+  // Paper excludes the final eval task from the forgetting sum
+  for (let j = 0; j < N - 1; j++) {
     let maxPerf = -Infinity;
     for (let k = 0; k < N; k++) {
-      maxPerf = Math.max(maxPerf, a[k][j] ?? 0);
+      maxPerf = Math.max(maxPerf, a[k][j]);
     }
-    const finalPerf = a[N - 1][j] ?? 0;
+    const finalPerf = a[N - 1][j];
     totalForgetting += Math.max(0, maxPerf - finalPerf);
   }
 
-  return totalForgetting / (numTasks - 1);
+  return totalForgetting / (N - 1);
 }
 
 /**
@@ -92,16 +108,11 @@ export function computeForgetting(a: number[][]): number {
  */
 function computePlasticity(a: number[][]): number {
   if (a.length === 0) return 0;
-
   let sum = 0;
-  let count = 0;
   for (let i = 0; i < a.length; i++) {
-    if (i < a[i].length) {
-      sum += a[i][i];
-      count++;
-    }
+    sum += a[i][i];
   }
-  return count > 0 ? sum / count : 0;
+  return sum / a.length;
 }
 
 /**
@@ -112,7 +123,6 @@ function computePlasticity(a: number[][]): number {
 function computeACC(a: number[][]): number {
   if (a.length === 0) return 0;
   const lastRow = a[a.length - 1];
-  if (lastRow.length === 0) return 0;
   return lastRow.reduce((s, v) => s + v, 0) / lastRow.length;
 }
 
@@ -121,12 +131,11 @@ function computeACC(a: number[][]): number {
  * CL-Fβ = (1 + β²) * P * S / (β² * P + S)
  * where P = plasticity, S = max(0, 1 - forgetting)
  *
- * @param a - Performance matrix a[trained_on][eval_task]
- * @param _baseline - Baseline (unused in Fβ, kept for API consistency)
+ * @param a - Square performance matrix a[trained_on][eval_task]
  * @param beta - Weight parameter (default 1 = equal weight)
  * @returns CL-Fβ score
  */
-export function computeCLFbeta(a: number[][], _baseline: number[], beta: number = 1): number {
+export function computeCLFbeta(a: number[][], beta: number = 1): number {
   if (a.length === 0) return 0;
 
   const plasticity = computePlasticity(a);
@@ -145,7 +154,7 @@ export function computeCLFbeta(a: number[][], _baseline: number[], beta: number 
  *
  * Simplified from the paper's full formula (BWT, AULC, TUE terms omitted).
  *
- * @param a - Performance matrix a[trained_on][eval_task]
+ * @param a - Square performance matrix a[trained_on][eval_task]
  * @param baseline - Baseline performance per task
  * @returns Composite CL score
  */
@@ -160,26 +169,47 @@ export function computeCLScore(a: number[][], baseline: number[]): number {
 }
 
 /**
- * Compute all CL metrics in one call.
+ * Compute all CL metrics in one call. Avoids redundant sub-computations.
  *
- * @param a - Performance matrix a[trained_on][eval_task]
+ * @param a - Square performance matrix a[trained_on][eval_task]
  * @param baseline - Baseline performance per task (no memory condition)
  * @returns All CL metrics
  */
 export function computeAllCLMetrics(a: number[][], baseline: number[]): CLMetricsResult {
+  if (a.length === 0) {
+    return {
+      forward_transfer: 0,
+      forgetting: 0,
+      plasticity: 0,
+      stability: 0,
+      cl_f_beta: 0,
+      cl_score: 0,
+    };
+  }
+
+  assertSquareMatrix(a, "computeAllCLMetrics");
+  const N = a.length;
+  if (baseline.length < N) {
+    throw new RangeError(
+      `computeAllCLMetrics: baseline length ${baseline.length} must be >= matrix size ${N}`
+    );
+  }
+
   const forward_transfer = computeForwardTransfer(a, baseline);
   const forgetting = computeForgetting(a);
   const plasticity = computePlasticity(a);
   const stability = Math.max(0, 1 - forgetting);
-  const cl_f_beta = computeCLFbeta(a, baseline);
-  const cl_score = computeCLScore(a, baseline);
+  const acc = computeACC(a);
 
-  return {
-    forward_transfer,
-    forgetting,
-    plasticity,
-    stability,
-    cl_f_beta,
-    cl_score,
-  };
+  // Inline CL-Fβ to avoid recomputing forgetting/plasticity
+  let cl_f_beta: number;
+  if (plasticity === 0 || stability === 0) {
+    cl_f_beta = 0;
+  } else {
+    cl_f_beta = (2 * plasticity * stability) / (plasticity + stability);
+  }
+
+  const cl_score = acc + forward_transfer - forgetting;
+
+  return { forward_transfer, forgetting, plasticity, stability, cl_f_beta, cl_score };
 }

--- a/experiments/benchmarks/cl-metrics.ts
+++ b/experiments/benchmarks/cl-metrics.ts
@@ -8,7 +8,9 @@
  *   a[i][j] = performance on task j after training through task i
  *   Rows = training stage (which task was last trained on)
  *   Columns = evaluation task
- *   Matrix MUST be square (N × N). Non-square input throws RangeError.
+ *   Matrix MUST be square (N × N). Non-square input throws RangeError (for N > 1;
+ *   N <= 1 returns 0 for transfer/forgetting metrics without validation).
+ *   All elements must be finite (NaN/Infinity throws RangeError).
  *   a[i][i] = diagonal = performance on task i when first introduced (plasticity)
  *   a[i][i+1] = superdiagonal = performance on next task after training on current
  *   a[N-1][j] = last row = final accuracy on task j after all training
@@ -40,6 +42,11 @@ function assertSquareMatrix(a: number[][], caller: string): void {
         `${caller}: matrix must be square (row ${i} has ${a[i].length} cols, expected ${N})`
       );
     }
+    for (let j = 0; j < N; j++) {
+      if (!Number.isFinite(a[i][j])) {
+        throw new RangeError(`${caller}: non-finite value at [${i}][${j}]: ${a[i][j]}`);
+      }
+    }
   }
 }
 
@@ -55,9 +62,10 @@ function assertSquareMatrix(a: number[][], caller: string): void {
  * @returns Mean forward transfer score. Returns 0 for N <= 1.
  */
 export function computeForwardTransfer(a: number[][], baseline: number[]): number {
+  if (a.length === 0) return 0;
+  assertSquareMatrix(a, "computeForwardTransfer");
   const N = a.length;
   if (N <= 1) return 0;
-  assertSquareMatrix(a, "computeForwardTransfer");
 
   if (baseline.length < N) {
     throw new RangeError(
@@ -74,25 +82,29 @@ export function computeForwardTransfer(a: number[][], baseline: number[]): numbe
 
 /**
  * Forgetting: measures how previously learned knowledge degrades over time.
- * F = (1/(N-1)) * Σ_{j=0}^{N-2} (max_{k: 0<=k<=N-1} a[k][j] - a[N-1][j])
+ * F = (1/(N-1)) * Σ_{j=0}^{N-2} max(0, max_{k=0}^{j} a[k][j] - a[N-1][j])
  *
  * For each eval task j (excluding the last), computes the gap between
- * peak performance (across all training stages) and final performance
- * (after training on all tasks).
+ * peak performance (up to training stage j, when task j was introduced)
+ * and final performance (after training on all tasks).
+ *
+ * The max range k=0..j follows the paper: peak is measured over training
+ * stages up to when the task was last directly trained, not globally.
  *
  * @param a - Square performance matrix a[trained_on][eval_task]
  * @returns Mean forgetting score (0 = no forgetting). Returns 0 for N <= 1.
  */
 export function computeForgetting(a: number[][]): number {
+  if (a.length === 0) return 0;
+  assertSquareMatrix(a, "computeForgetting");
   const N = a.length;
   if (N <= 1) return 0;
-  assertSquareMatrix(a, "computeForgetting");
 
   let totalForgetting = 0;
-  // Paper excludes the final eval task from the forgetting sum
   for (let j = 0; j < N - 1; j++) {
     let maxPerf = -Infinity;
-    for (let k = 0; k < N; k++) {
+    // Peak performance on task j up to training stage j (paper: max_{1≤k≤j})
+    for (let k = 0; k <= j; k++) {
       maxPerf = Math.max(maxPerf, a[k][j]);
     }
     const finalPerf = a[N - 1][j];
@@ -137,6 +149,7 @@ function computeACC(a: number[][]): number {
  */
 export function computeCLFbeta(a: number[][], beta: number = 1): number {
   if (a.length === 0) return 0;
+  assertSquareMatrix(a, "computeCLFbeta");
 
   const plasticity = computePlasticity(a);
   const forgetting = computeForgetting(a);
@@ -170,10 +183,11 @@ export function computeCLScore(a: number[][], baseline: number[]): number {
 
 /**
  * Compute all CL metrics in one call. Avoids redundant sub-computations.
+ * CL-Fβ is computed with β=1 (standard harmonic mean).
  *
  * @param a - Square performance matrix a[trained_on][eval_task]
  * @param baseline - Baseline performance per task (no memory condition)
- * @returns All CL metrics
+ * @returns All CL metrics (cl_f_beta uses β=1)
  */
 export function computeAllCLMetrics(a: number[][], baseline: number[]): CLMetricsResult {
   if (a.length === 0) {
@@ -201,7 +215,7 @@ export function computeAllCLMetrics(a: number[][], baseline: number[]): CLMetric
   const stability = Math.max(0, 1 - forgetting);
   const acc = computeACC(a);
 
-  // Inline CL-Fβ to avoid recomputing forgetting/plasticity
+  // Inline CL-Fβ (β=1) to avoid recomputing forgetting/plasticity
   let cl_f_beta: number;
   if (plasticity === 0 || stability === 0) {
     cl_f_beta = 0;

--- a/experiments/benchmarks/cl-metrics.ts
+++ b/experiments/benchmarks/cl-metrics.ts
@@ -50,6 +50,20 @@ function assertSquareMatrix(a: number[][], caller: string): void {
   }
 }
 
+/** Validate that baseline has sufficient length and all finite values. */
+function assertBaseline(baseline: number[], N: number, caller: string): void {
+  if (baseline.length < N) {
+    throw new RangeError(
+      `${caller}: baseline length ${baseline.length} must be >= matrix size ${N}`
+    );
+  }
+  for (let i = 0; i < N; i++) {
+    if (!Number.isFinite(baseline[i])) {
+      throw new RangeError(`${caller}: non-finite baseline value at [${i}]: ${baseline[i]}`);
+    }
+  }
+}
+
 /**
  * Forward Transfer: measures how past experience improves performance on new tasks.
  * FT = (1/(N-1)) * Σ_{i=0}^{N-2} (a[i][i+1] - baseline[i+1])
@@ -67,11 +81,7 @@ export function computeForwardTransfer(a: number[][], baseline: number[]): numbe
   const N = a.length;
   if (N <= 1) return 0;
 
-  if (baseline.length < N) {
-    throw new RangeError(
-      `computeForwardTransfer: baseline length ${baseline.length} must be >= matrix size ${N}`
-    );
-  }
+  assertBaseline(baseline, N, "computeForwardTransfer");
 
   let sum = 0;
   for (let i = 0; i < N - 1; i++) {
@@ -173,6 +183,7 @@ export function computeCLFbeta(a: number[][], beta: number = 1): number {
  */
 export function computeCLScore(a: number[][], baseline: number[]): number {
   if (a.length === 0) return 0;
+  assertSquareMatrix(a, "computeCLScore");
 
   const acc = computeACC(a);
   const fwt = computeForwardTransfer(a, baseline);
@@ -203,11 +214,7 @@ export function computeAllCLMetrics(a: number[][], baseline: number[]): CLMetric
 
   assertSquareMatrix(a, "computeAllCLMetrics");
   const N = a.length;
-  if (baseline.length < N) {
-    throw new RangeError(
-      `computeAllCLMetrics: baseline length ${baseline.length} must be >= matrix size ${N}`
-    );
-  }
+  assertBaseline(baseline, N, "computeAllCLMetrics");
 
   const forward_transfer = computeForwardTransfer(a, baseline);
   const forgetting = computeForgetting(a);

--- a/experiments/benchmarks/scripts/aggregate.ts
+++ b/experiments/benchmarks/scripts/aggregate.ts
@@ -112,6 +112,8 @@ export function aggregateByCondition(results: BenchmarkResult[]): ConditionSumma
       mean_forgetting: optionalMean(runs.map((r) => r.metrics.forgetting)),
       mean_corrective_rate: optionalMean(runs.map((r) => r.metrics.corrective_rate)),
       mean_completion_rate: optionalMean(runs.map((r) => r.metrics.completion_rate)),
+      mean_cl_f_beta: optionalMean(runs.map((r) => r.metrics.cl_f_beta)),
+      mean_cl_score: optionalMean(runs.map((r) => r.metrics.cl_score)),
     });
   }
 
@@ -144,6 +146,8 @@ export function formatMarkdownTable(table: ComparisonTable): string {
     "Forgetting",
     "Corrective",
     "Completion",
+    "CL-Fβ",
+    "CL-Score",
   ];
   lines.push(`| ${headers.join(" | ")} |`);
   lines.push(`| ${headers.map(() => "---").join(" | ")} |`);
@@ -158,6 +162,8 @@ export function formatMarkdownTable(table: ComparisonTable): string {
       c.mean_forgetting?.toFixed(3) ?? "-",
       c.mean_corrective_rate?.toFixed(3) ?? "-",
       c.mean_completion_rate?.toFixed(3) ?? "-",
+      c.mean_cl_f_beta?.toFixed(3) ?? "-",
+      c.mean_cl_score?.toFixed(3) ?? "-",
     ];
     lines.push(`| ${row.join(" | ")} |`);
   }

--- a/experiments/benchmarks/types.ts
+++ b/experiments/benchmarks/types.ts
@@ -19,6 +19,8 @@ export const benchmarkMetricsSchema = z.object({
   forgetting: z.number().optional().describe("Forgetting rate (SWE-Bench-CL)"),
   corrective_rate: z.number().min(0).max(1).optional().describe("Corrective instruction rate"),
   completion_rate: z.number().min(0).max(1).optional().describe("Task completion rate"),
+  cl_f_beta: z.number().optional().describe("CL-Fβ: harmonic mean of plasticity and stability"),
+  cl_score: z.number().optional().describe("CL-Score: composite continual learning score"),
 });
 
 export type BenchmarkMetrics = z.infer<typeof benchmarkMetricsSchema>;
@@ -85,6 +87,8 @@ export interface ConditionSummary {
   mean_forgetting?: number;
   mean_corrective_rate?: number;
   mean_completion_rate?: number;
+  mean_cl_f_beta?: number;
+  mean_cl_score?: number;
 }
 
 export interface ComparisonTable {

--- a/experiments/benchmarks/types.ts
+++ b/experiments/benchmarks/types.ts
@@ -15,8 +15,12 @@ export const benchmarkConditionSchema = z.enum(BENCHMARK_CONDITIONS);
 
 export const benchmarkMetricsSchema = z.object({
   pass_at_1: z.number().min(0).max(1).describe("Pass@1 rate"),
-  forward_transfer: z.number().optional().describe("Forward transfer score (SWE-Bench-CL)"),
-  forgetting: z.number().optional().describe("Forgetting rate (SWE-Bench-CL)"),
+  forward_transfer: z
+    .number()
+    .finite()
+    .optional()
+    .describe("Forward transfer score (SWE-Bench-CL)"),
+  forgetting: z.number().finite().min(0).optional().describe("Forgetting score (SWE-Bench-CL)"),
   corrective_rate: z.number().min(0).max(1).optional().describe("Corrective instruction rate"),
   completion_rate: z.number().min(0).max(1).optional().describe("Task completion rate"),
   cl_f_beta: z

--- a/experiments/benchmarks/types.ts
+++ b/experiments/benchmarks/types.ts
@@ -19,8 +19,13 @@ export const benchmarkMetricsSchema = z.object({
   forgetting: z.number().optional().describe("Forgetting rate (SWE-Bench-CL)"),
   corrective_rate: z.number().min(0).max(1).optional().describe("Corrective instruction rate"),
   completion_rate: z.number().min(0).max(1).optional().describe("Task completion rate"),
-  cl_f_beta: z.number().optional().describe("CL-Fβ: harmonic mean of plasticity and stability"),
-  cl_score: z.number().optional().describe("CL-Score: composite continual learning score"),
+  cl_f_beta: z
+    .number()
+    .min(0)
+    .max(1)
+    .optional()
+    .describe("CL-Fβ: harmonic mean of plasticity and stability"),
+  cl_score: z.number().finite().optional().describe("CL-Score: composite continual learning score"),
 });
 
 export type BenchmarkMetrics = z.infer<typeof benchmarkMetricsSchema>;


### PR DESCRIPTION
## Summary

- SWE-Bench-CL 論文 (arXiv:2507.00014 Section 7) の Continual Learning メトリクスを TypeScript 純粋関数として実装
- 行列規約: `a[i][j]` = task j の性能 after training through task i（論文と一致）
- Forward Transfer (superdiagonal), Forgetting (column-based, N-1 denominator), CL-Fβ (plasticity-stability harmonic mean), CL-Score (ACC + FWT - Forgetting)
- BenchmarkMetrics スキーマに `cl_f_beta`, `cl_score` を追加
- aggregate.ts の Markdown テーブルに CL-Fβ, CL-Score 列を追加
- 25 新規テスト、全 602 テストパス

Closes #106

## Test plan

- [x] `npx vitest run experiments/benchmarks/__tests__/cl-metrics.test.ts` — 25 テスト全パス
- [x] `npx vitest run` — 602 テスト全パス（回帰なし）
- [x] `npx tsc --noEmit` — 型エラーなし
- [x] Code review 2回実施: 数式の正確性検証、行列規約の統一

🤖 Generated with [Claude Code](https://claude.com/claude-code)