### PR TITLE
feat: add process metrics (token_usage, attempt_count) (#110)

### DIFF
--- a/experiments/benchmarks/__tests__/benchmark-types.test.ts
+++ b/experiments/benchmarks/__tests__/benchmark-types.test.ts
@@ -61,6 +61,26 @@ describe("benchmarkResultSchema", () => {
     };
     const parsed = benchmarkResultSchema.parse(minimal);
     expect(parsed.metrics.forward_transfer).toBeUndefined();
+    expect(parsed.metrics.token_usage).toBeUndefined();
+    expect(parsed.metrics.attempt_count).toBeUndefined();
+  });
+
+  it("accepts result with process metrics", () => {
+    const withProcess = {
+      ...validResult,
+      metrics: { ...validResult.metrics, token_usage: 15000, attempt_count: 3 },
+    };
+    const parsed = benchmarkResultSchema.parse(withProcess);
+    expect(parsed.metrics.token_usage).toBe(15000);
+    expect(parsed.metrics.attempt_count).toBe(3);
+  });
+
+  it("rejects negative token_usage", () => {
+    expect(() => benchmarkMetricsSchema.parse({ pass_at_1: 0.5, token_usage: -1 })).toThrow();
+  });
+
+  it("rejects negative attempt_count", () => {
+    expect(() => benchmarkMetricsSchema.parse({ pass_at_1: 0.5, attempt_count: -1 })).toThrow();
   });
 
   it("accepts result with per-task details", () => {
@@ -160,10 +180,24 @@ describe("aggregation", () => {
   it("includes optional metrics when present", () => {
     const results = [
       makeResult("acm", 0.7, {
-        metrics: { pass_at_1: 0.7, forward_transfer: 0.1, forgetting: 0.02, corrective_rate: 0.05 },
+        metrics: {
+          pass_at_1: 0.7,
+          forward_transfer: 0.1,
+          forgetting: 0.02,
+          corrective_rate: 0.05,
+          token_usage: 10000,
+          attempt_count: 2,
+        },
       }),
       makeResult("acm", 0.8, {
-        metrics: { pass_at_1: 0.8, forward_transfer: 0.2, forgetting: 0.03, corrective_rate: 0.1 },
+        metrics: {
+          pass_at_1: 0.8,
+          forward_transfer: 0.2,
+          forgetting: 0.03,
+          corrective_rate: 0.1,
+          token_usage: 14000,
+          attempt_count: 4,
+        },
       }),
     ];
 
@@ -172,12 +206,16 @@ describe("aggregation", () => {
     expect(acm.mean_forward_transfer).toBeCloseTo(0.15, 4);
     expect(acm.mean_forgetting).toBeCloseTo(0.025, 4);
     expect(acm.mean_corrective_rate).toBeCloseTo(0.075, 4);
+    expect(acm.mean_token_usage).toBeCloseTo(12000, 4);
+    expect(acm.mean_attempt_count).toBeCloseTo(3, 4);
   });
 
   it("leaves optional metrics undefined when not present", () => {
     const results = [makeResult("baseline", 0.5)];
     const summaries = aggregateByCondition(results);
     expect(summaries[0].mean_forward_transfer).toBeUndefined();
+    expect(summaries[0].mean_token_usage).toBeUndefined();
+    expect(summaries[0].mean_attempt_count).toBeUndefined();
   });
 
   it("averages only defined values when optional metrics are mixed", () => {
@@ -271,6 +309,8 @@ describe("formatMarkdownTable", () => {
     expect(md).toContain("acm");
     expect(md).toContain("0.500");
     expect(md).toContain("0.800");
+    expect(md).toContain("Tokens");
+    expect(md).toContain("Attempts");
   });
 });
 

--- a/experiments/benchmarks/scripts/aggregate.ts
+++ b/experiments/benchmarks/scripts/aggregate.ts
@@ -114,6 +114,8 @@ export function aggregateByCondition(results: BenchmarkResult[]): ConditionSumma
       mean_completion_rate: optionalMean(runs.map((r) => r.metrics.completion_rate)),
       mean_cl_f_beta: optionalMean(runs.map((r) => r.metrics.cl_f_beta)),
       mean_cl_score: optionalMean(runs.map((r) => r.metrics.cl_score)),
+      mean_token_usage: optionalMean(runs.map((r) => r.metrics.token_usage)),
+      mean_attempt_count: optionalMean(runs.map((r) => r.metrics.attempt_count)),
     });
   }
 
@@ -148,6 +150,8 @@ export function formatMarkdownTable(table: ComparisonTable): string {
     "Completion",
     "CL-Fβ",
     "CL-Score",
+    "Tokens",
+    "Attempts",
   ];
   lines.push(`| ${headers.join(" | ")} |`);
   lines.push(`| ${headers.map(() => "---").join(" | ")} |`);
@@ -164,6 +168,8 @@ export function formatMarkdownTable(table: ComparisonTable): string {
       c.mean_completion_rate?.toFixed(3) ?? "-",
       c.mean_cl_f_beta?.toFixed(3) ?? "-",
       c.mean_cl_score?.toFixed(3) ?? "-",
+      c.mean_token_usage?.toFixed(0) ?? "-",
+      c.mean_attempt_count?.toFixed(1) ?? "-",
     ];
     lines.push(`| ${row.join(" | ")} |`);
   }

--- a/experiments/benchmarks/types.ts
+++ b/experiments/benchmarks/types.ts
@@ -30,6 +30,13 @@ export const benchmarkMetricsSchema = z.object({
     .optional()
     .describe("CL-Fβ: harmonic mean of plasticity and stability"),
   cl_score: z.number().finite().optional().describe("CL-Score: composite continual learning score"),
+  token_usage: z.number().int().min(0).optional().describe("Total tokens consumed in the session"),
+  attempt_count: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Number of attempts to complete the task"),
 });
 
 export type BenchmarkMetrics = z.infer<typeof benchmarkMetricsSchema>;
@@ -98,6 +105,8 @@ export interface ConditionSummary {
   mean_completion_rate?: number;
   mean_cl_f_beta?: number;
   mean_cl_score?: number;
+  mean_token_usage?: number;
+  mean_attempt_count?: number;
 }
 
 export interface ComparisonTable {

--- a/experiments/harness/metric-collector.ts
+++ b/experiments/harness/metric-collector.ts
@@ -18,6 +18,8 @@ export interface CollectInput {
   completion_rate: number;
   signals?: SignalData;
   sessionLog?: SessionLogData;
+  token_usage?: number;
+  attempt_count?: number;
 }
 
 export class MetricCollector {
@@ -32,6 +34,8 @@ export class MetricCollector {
       interrupt_count: input.signals?.interrupt_count ?? 0,
       corrective_instruction_count: input.signals?.corrective_instruction_count ?? 0,
       context_tokens_used: input.sessionLog?.context_tokens_used ?? 0,
+      token_usage: input.token_usage ?? 0,
+      attempt_count: input.attempt_count ?? 0,
       timestamp: new Date().toISOString(),
     };
   }

--- a/experiments/harness/report-generator.ts
+++ b/experiments/harness/report-generator.ts
@@ -21,6 +21,8 @@ const CSV_COLUMNS = [
   "interrupt_count",
   "corrective_instruction_count",
   "context_tokens_used",
+  "token_usage",
+  "attempt_count",
   "duration_ms",
   "error",
   "timestamp",
@@ -80,6 +82,8 @@ export class ReportGenerator {
       const interruptCounts = group.map((r) => r.metrics.interrupt_count);
       const correctiveCounts = group.map((r) => r.metrics.corrective_instruction_count);
       const contextTokens = group.map((r) => r.metrics.context_tokens_used);
+      const tokenUsages = group.map((r) => r.metrics.token_usage);
+      const attemptCounts = group.map((r) => r.metrics.attempt_count);
 
       results.push({
         condition,
@@ -91,6 +95,10 @@ export class ReportGenerator {
         std_corrective_count: standardDeviation(correctiveCounts),
         mean_context_tokens: mean(contextTokens),
         std_context_tokens: standardDeviation(contextTokens),
+        mean_token_usage: mean(tokenUsages),
+        std_token_usage: standardDeviation(tokenUsages),
+        mean_attempt_count: mean(attemptCounts),
+        std_attempt_count: standardDeviation(attemptCounts),
         run_count: group.length,
       });
     }
@@ -118,6 +126,8 @@ export class ReportGenerator {
       m.interrupt_count,
       m.corrective_instruction_count,
       m.context_tokens_used,
+      m.token_usage,
+      m.attempt_count,
       run.duration_ms,
       run.error ?? "",
       m.timestamp,

--- a/experiments/harness/types.ts
+++ b/experiments/harness/types.ts
@@ -20,8 +20,8 @@ export interface MetricSet {
   interrupt_count: number;
   corrective_instruction_count: number;
   context_tokens_used: number;
-  token_usage: number; // total tokens consumed in the session
-  attempt_count: number; // number of attempts to complete the task
+  token_usage: number;
+  attempt_count: number;
   timestamp: string;
 }
 

--- a/experiments/harness/types.ts
+++ b/experiments/harness/types.ts
@@ -20,6 +20,8 @@ export interface MetricSet {
   interrupt_count: number;
   corrective_instruction_count: number;
   context_tokens_used: number;
+  token_usage: number; // total tokens consumed in the session
+  attempt_count: number; // number of attempts to complete the task
   timestamp: string;
 }
 
@@ -40,6 +42,10 @@ export interface AggregatedConditionResult {
   std_corrective_count: number;
   mean_context_tokens: number;
   std_context_tokens: number;
+  mean_token_usage: number;
+  std_token_usage: number;
+  mean_attempt_count: number;
+  std_attempt_count: number;
   run_count: number;
 }
 

--- a/tests/experiments/metric-collector.test.ts
+++ b/tests/experiments/metric-collector.test.ts
@@ -20,6 +20,8 @@ describe("MetricCollector", () => {
         sessionLog: {
           context_tokens_used: 50000,
         },
+        token_usage: 12000,
+        attempt_count: 3,
       });
 
       expect(result.run_id).toBe("run-001");
@@ -31,6 +33,8 @@ describe("MetricCollector", () => {
       expect(result.interrupt_count).toBe(3);
       expect(result.corrective_instruction_count).toBe(1);
       expect(result.context_tokens_used).toBe(50000);
+      expect(result.token_usage).toBe(12000);
+      expect(result.attempt_count).toBe(3);
       expect(result.timestamp).toBeDefined();
     });
 
@@ -56,7 +60,7 @@ describe("MetricCollector", () => {
       expect(result.task_completion_rate).toBe(1.0);
     });
 
-    it("uses default values when signals are not provided", () => {
+    it("uses default values when signals and process metrics are not provided", () => {
       const result = collector.collect({
         run_id: "run-003",
         condition: "control",
@@ -69,6 +73,8 @@ describe("MetricCollector", () => {
       expect(result.interrupt_count).toBe(0);
       expect(result.corrective_instruction_count).toBe(0);
       expect(result.context_tokens_used).toBe(0);
+      expect(result.token_usage).toBe(0);
+      expect(result.attempt_count).toBe(0);
     });
 
     it("generates ISO timestamp", () => {

--- a/tests/experiments/report-generator.test.ts
+++ b/tests/experiments/report-generator.test.ts
@@ -13,6 +13,8 @@ function makeRunResult(overrides: Partial<RunResult> & { spec: RunSpec }): RunRe
     interrupt_count: 2,
     corrective_instruction_count: 1,
     context_tokens_used: 50000,
+    token_usage: 10000,
+    attempt_count: 2,
     timestamp: "2026-03-10T00:00:00.000Z",
   };
   return {
@@ -47,6 +49,8 @@ describe("ReportGenerator", () => {
             interrupt_count: 3,
             corrective_instruction_count: 2,
             context_tokens_used: 60000,
+            token_usage: 15000,
+            attempt_count: 4,
             timestamp: "2026-03-10T00:00:00.000Z",
           },
         }),
@@ -68,6 +72,8 @@ describe("ReportGenerator", () => {
             interrupt_count: 1,
             corrective_instruction_count: 0,
             context_tokens_used: 40000,
+            token_usage: 9000,
+            attempt_count: 2,
             timestamp: "2026-03-10T00:01:00.000Z",
           },
         }),
@@ -89,6 +95,8 @@ describe("ReportGenerator", () => {
             interrupt_count: 0,
             corrective_instruction_count: 0,
             context_tokens_used: 45000,
+            token_usage: 8000,
+            attempt_count: 1,
             timestamp: "2026-03-10T00:02:00.000Z",
           },
         }),
@@ -108,12 +116,16 @@ describe("ReportGenerator", () => {
       expect(controlAgg!.mean_completion_rate).toBeCloseTo(0.7, 5);
       expect(controlAgg!.run_count).toBe(2);
       expect(controlAgg!.mean_interrupt_count).toBeCloseTo(2, 5);
+      expect(controlAgg!.mean_token_usage).toBeCloseTo(12000, 5);
+      expect(controlAgg!.mean_attempt_count).toBeCloseTo(3, 5);
 
       // Check acm-sf aggregation
       const acmAgg = report.aggregated.find((a) => a.condition === "acm-sf");
       expect(acmAgg).toBeDefined();
       expect(acmAgg!.mean_completion_rate).toBeCloseTo(0.9, 5);
       expect(acmAgg!.run_count).toBe(1);
+      expect(acmAgg!.mean_token_usage).toBeCloseTo(8000, 5);
+      expect(acmAgg!.mean_attempt_count).toBeCloseTo(1, 5);
     });
 
     it("handles empty runs", () => {
@@ -145,6 +157,8 @@ describe("ReportGenerator", () => {
       expect(lines[0]).toContain("condition");
       expect(lines[0]).toContain("task");
       expect(lines[0]).toContain("task_completion_rate");
+      expect(lines[0]).toContain("token_usage");
+      expect(lines[0]).toContain("attempt_count");
 
       // Data line
       expect(lines[1]).toContain("r1");


### PR DESCRIPTION
## Summary
- `MetricSet` と `BenchmarkMetrics` に `token_usage`, `attempt_count` を追加
- `MetricCollector`, `ReportGenerator` (CSV/JSON), `aggregate.ts` (Markdown テーブル) に反映
- `ConditionSummary` に `mean_token_usage`, `mean_attempt_count` を追加
- 評価設計の再検討（天井効果対策）に基づく process metrics 導入

## Test plan
- [x] 619 テスト全 pass（新規テスト 3 件追加、既存テスト更新）
- [x] `tsc` ビルド成功
- [x] Zod スキーマで `token_usage >= 0`, `attempt_count >= 0` のバリデーション確認

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)