### PR TITLE
fix(plugin): comply with userConfig manifest schema

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,19 +14,26 @@
       "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/start-mcp.sh"]
     }
   },
-  "hooks": "./hooks/hooks.json",
   "skills": "./skills",
   "userConfig": {
     "ollama_url": {
+      "type": "string",
+      "title": "Ollama API URL",
       "description": "Ollama API URL for corrective instruction classification (default: http://localhost:11434)"
     },
     "ollama_model": {
+      "type": "string",
+      "title": "Ollama Model",
       "description": "Ollama model name for corrective classification (default: gemma2:2b)"
     },
     "verbosity": {
+      "type": "string",
+      "title": "Verbosity Level",
       "description": "ACM output detail level: quiet, normal, or verbose (default: normal)"
     },
     "max_experiences_per_project": {
+      "type": "number",
+      "title": "Max Experiences Per Project",
       "description": "Maximum experience entries per project before GC triggers (default: 500)"
     }
   }

--- a/tests/plugin-structure.test.ts
+++ b/tests/plugin-structure.test.ts
@@ -25,7 +25,10 @@ describe("plugin.json", () => {
     expect(plugin.name).toBe("acm");
     expect(plugin.description).toBeTruthy();
     expect(plugin.mcpServers).toBeDefined();
-    expect(plugin.hooks).toBe("./hooks/hooks.json");
+    // `hooks` field is intentionally omitted — Claude Code auto-discovers
+    // the standard hooks/hooks.json path; declaring it caused a
+    // "Duplicate hooks file detected" load error.
+    expect(plugin.hooks).toBeUndefined();
     expect(plugin.skills).toBe("./skills");
   });
 


### PR DESCRIPTION
## Summary

- Add `type` and `title` to each `userConfig` entry (required by Claude Code plugin schema)
- Remove `"hooks": "./hooks/hooks.json"` — the standard path is auto-discovered; declaring it caused `Duplicate hooks file detected` at load time
- Update `tests/plugin-structure.test.ts` to assert `hooks` is undefined

## Why

Claude Code's `/plugin` UI was rejecting the manifest:
```
userConfig.ollama_url.type: Invalid option
userConfig.ollama_url.title: Invalid input: expected string, received undefined
...
```
The plugin wouldn't load, breaking ACM integration on any session that reloaded plugins.

## Test plan

- [x] `npx vitest run tests/plugin-structure.test.ts` — 8/8 pass
- [ ] 手動検証: `/reload-plugins` → ACM が Errors tab に出ず Installed にロードされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)