### PR TITLE
chore(plugin): drop non-standard user-invocable frontmatter

### DIFF
--- a/skills/health/SKILL.md
+++ b/skills/health/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: health
 description: Check ACM MCP server health status (version, timestamp).
-user-invocable: true
 ---
 
 # ACM Health Check

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: report
 description: Generate a cross-project ACM analysis report showing usage statistics and injection-to-outcome episodes.
-user-invocable: true
 ---
 
 # ACM Report


### PR DESCRIPTION
## Summary

Remove `user-invocable: true` from `skills/health/SKILL.md` and `skills/report/SKILL.md`.

## Why

The Claude Code plugins-reference schema (https://code.claude.com/docs/en/plugins-reference) does not list `user-invocable` as a valid SKILL.md frontmatter field. Skills are user- and model-invocable by default; the field is redundant and non-standard. Removing it for spec compliance.

Invocation names remain `/acm:report` and `/acm:health` — unchanged.

## Test plan

- [ ] 手動検証: `/reload-plugins` 後、`/plugin` に ACM が正常表示、`/acm:health` / `/acm:report` が起動する

🤖 Generated with [Claude Code](https://claude.com/claude-code)