### PR TITLE
refactor(plugin): migrate skills/ to commands/ for slash-command display

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,7 +14,6 @@
       "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/start-mcp.sh"]
     }
   },
-  "skills": "./skills",
   "userConfig": {
     "ollama_url": {
       "type": "string",

--- a/commands/health.md
+++ b/commands/health.md
@@ -1,7 +1,6 @@
 ---
 name: health
 description: Check ACM MCP server health status (version, timestamp).
-user-invocable: true
 ---
 
 # ACM Health Check

--- a/commands/report.md
+++ b/commands/report.md
@@ -1,7 +1,6 @@
 ---
 name: report
 description: Generate a cross-project ACM analysis report showing usage statistics and injection-to-outcome episodes.
-user-invocable: true
 ---
 
 # ACM Report

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -26,8 +26,8 @@
 **プラグイン構造**:
 - `.claude-plugin/plugin.json` — MCP サーバー定義、hooks 参照、userConfig、skills
 - `hooks/hooks.json` — Claude Code hook イベントマッピング（7 hooks: SessionStart, Stop, SessionEnd, PreCompact, PostToolUse, PostToolUseFailure, UserPromptSubmit）
-- `skills/report/SKILL.md` — `/acm:report` スキル（acm_report の結果をフォーマット表示）
-- `skills/health/SKILL.md` — `/acm:health` スキル（ACM 稼働状態チェック）
+- `commands/report.md` — `/acm:report` コマンド（acm_report の結果をフォーマット表示）
+- `commands/health.md` — `/acm:health` コマンド（ACM 稼働状態チェック）
 - `userConfig` — ユーザー設定（ollama_url, ollama_model, verbosity, max_experiences_per_project）。値は `CLAUDE_PLUGIN_OPTION_<KEY>` 環境変数として hook プロセスに渡される
 - インストール時、hook は自動的に登録され、`ACM_CONFIG_PATH` 未設定でも `DEFAULT_CONFIG`（`mode: "full"`, `db_path: "~/.acm/experiences.db"`）で動作する
 

--- a/docs/research/commands-vs-skills-2026-04-20.md
+++ b/docs/research/commands-vs-skills-2026-04-20.md
@@ -1,0 +1,100 @@
+# Research: `commands/` vs `skills/` in Claude Code plugins
+
+## Research Date
+2026-04-20
+
+## Research Purpose
+
+ACM プラグインで slash command を `/acm:report` / `/acm:health` の形で autocomplete dropdown に表示させたい。`skills/` 配置では `/report` `/health` と prefix 無しで表示されてしまう。`commands/` と `skills/` の使い分けのベストプラクティスを明文化する。
+
+## Research Method
+
+- 公式 docs の精読:
+  - https://code.claude.com/docs/en/plugins-reference
+  - https://code.claude.com/docs/en/skills
+- 実機観測（empirical）:
+  - CVI プラグイン（`commands/*.md` 配置）: dropdown が `/cvi:lang` 等 prefix 付き
+  - ACM プラグイン（`skills/<name>/SKILL.md` 配置）: dropdown が `/report` 等 prefix 無し
+- 他プラグインの layout 確認:
+  - `code` plugin は `commands/` と `skills/` 両方配置（同名、hybrid pattern）
+  - `cvi` plugin は `commands/*.md` 主体、`skills/voice-integration/SKILL.md` は model-invocable background skill
+
+## Summary of Findings
+
+### 公式 docs の建前
+
+> Custom commands have been merged into skills. A file at `.claude/commands/deploy.md` and a skill at `.claude/skills/deploy/SKILL.md` both create `/deploy` and work the same way.
+>
+> ... commands/ is the legacy format. Use skills/ for new plugins.
+
+機能上は skills の superset という立て付け。
+
+### 実機観測での差異
+
+公式 docs にない **dropdown 表示挙動の差**:
+
+| Layout | Dropdown 表示例 |
+|---|---|
+| `commands/lang.md` | `/cvi:lang`（prefix 付き） |
+| `skills/report/SKILL.md` | `/report`（prefix 無し） |
+
+同一 plugin 内の skill 登録はどちらも `plugin:name` namespace で行われる（system-reminder の skill 一覧や Skill tool 呼び出しでは両方 prefix 付き）が、**slash command palette への登録時に `commands/` 由来は prefix 保持、`skills/` 由来は prefix 省略**される。
+
+### 機能比較
+
+| 機能 | `commands/*.md` | `skills/<name>/SKILL.md` |
+|---|---|---|
+| slash command 登録 | ✅ | ✅ |
+| frontmatter 全種類 | ✅ | ✅ |
+| user invocation | ✅ | ✅（`user-invocable: false` で無効化）|
+| model (auto) invocation | ✅ | ✅（`disable-model-invocation: true` で無効化）|
+| bundled scripts (Python/bash) | ❌（単一 .md のみ）| ✅（`scripts/`, `reference.md` 等）|
+| `context: fork` サブエージェント実行 | ✅ | ✅ |
+| `` !`command` `` dynamic context injection | ✅ | ✅ |
+| 多ファイル segment load | ❌ | ✅ |
+| **dropdown 表示** | **`/plugin:name` prefix 付き** | **prefix 無し** |
+
+## 使い分けの判断基準
+
+### `commands/*.md` を選ぶケース
+
+- 単発の slash action（`/commit`, `/deploy`, `/report` のようなボタン感覚）
+- 供給ファイル（script, template, reference.md 等）不要
+- **dropdown に `/plugin:name` で prefix 込みで見せたい**
+- backward compat を気にする
+
+### `skills/<name>/SKILL.md` を選ぶケース
+
+- Python / bash script を同梱する（例: PDF processor, codebase visualizer）
+- 長大な reference material を progressive に load したい
+- 複数ファイルで構成される複雑な workflow
+- model による自動呼び出しが主目的で dropdown 表示は二次的
+
+### `commands/` + `skills/` 両方置くケース（`code` plugin 方式）
+
+- 共存可能（同名でも問題なし、slash 命名空間は共有）
+- `commands/` が dropdown 表示を担当、`skills/` が model-invocation + 拡張機能を担当
+- **最もリッチ**だが重複管理コストあり
+- 判断が難しい場合の「逃げ道」として有用
+
+## 結論（ACM の場合）
+
+`acm:report` と `acm:health` は MCP tool を叩く単純 wrapper。scripts 不要、reference 不要、動的 context 注入不要 → **`commands/*.md` 一択**。
+
+将来 supporting files が必要になったら `skills/` に昇格、もしくは Code plugin 方式で両方併設に移行可能。
+
+## リスクと注意
+
+- `commands/` は公式 docs 上は「legacy format」表記。将来的に廃止される可能性がゼロではない
+- ただし現状 Claude Code 本体でサポートは継続しており、実プラグイン（CVI, Code 等公式周辺）で広く使われている
+- 廃止アナウンスが出たら `skills/` 側の dropdown 表示が改善されているはずなので、その時点で再移行すればよい
+
+## 参考: 実際の plugin での選択例
+
+| Plugin | `commands/` | `skills/` | 方針 |
+|---|---|---|---|
+| `cvi` | ✅（9 files）| ✅（1 background skill）| commands 主体、skills は model-invocable background |
+| `code` | ✅（10 files）| ✅（10 同名）| hybrid（両方）|
+| `ypm` | ✅ | （要確認）| commands 主体 |
+| `acm`（本 PR 以前）| ❌ | ✅（2 files）| skills 単体 → dropdown prefix 無し問題 |
+| `acm`（本 PR 以後）| ✅（2 files）| ❌ | commands 単体 → dropdown prefix あり |

--- a/tests/plugin-structure.test.ts
+++ b/tests/plugin-structure.test.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 
 const ROOT = join(import.meta.dirname ?? ".", "..");
 const HOOKS_DIR = join(ROOT, "hooks");
-const SKILLS_DIR = join(ROOT, "skills");
+const COMMANDS_DIR = join(ROOT, "commands");
 
 function readJson(path: string): unknown {
   return JSON.parse(readFileSync(path, "utf-8"));
@@ -25,11 +25,12 @@ describe("plugin.json", () => {
     expect(plugin.name).toBe("acm");
     expect(plugin.description).toBeTruthy();
     expect(plugin.mcpServers).toBeDefined();
-    // `hooks` field is intentionally omitted — Claude Code auto-discovers
-    // the standard hooks/hooks.json path; declaring it caused a
-    // "Duplicate hooks file detected" load error.
+    // `hooks` and `skills` / `commands` fields are intentionally omitted —
+    // Claude Code auto-discovers the standard paths; declaring `hooks`
+    // caused a "Duplicate hooks file detected" load error.
     expect(plugin.hooks).toBeUndefined();
-    expect(plugin.skills).toBe("./skills");
+    expect(plugin.skills).toBeUndefined();
+    expect(plugin.commands).toBeUndefined();
   });
 
   it("has author with correct name", () => {
@@ -85,11 +86,11 @@ describe("hooks.json", () => {
   });
 });
 
-describe("skills", () => {
-  it("has report skill SKILL.md", () => {
-    const skillPath = join(SKILLS_DIR, "report", "SKILL.md");
-    expect(existsSync(skillPath)).toBe(true);
-    const content = readFileSync(skillPath, "utf-8");
+describe("commands", () => {
+  it("has report.md command", () => {
+    const cmdPath = join(COMMANDS_DIR, "report.md");
+    expect(existsSync(cmdPath)).toBe(true);
+    const content = readFileSync(cmdPath, "utf-8");
     // Frontmatter check
     expect(content).toMatch(/^---\n/);
     expect(content).toMatch(/name:\s*report/);
@@ -98,10 +99,10 @@ describe("skills", () => {
     expect(content).toContain("acm_report");
   });
 
-  it("has health skill SKILL.md", () => {
-    const skillPath = join(SKILLS_DIR, "health", "SKILL.md");
-    expect(existsSync(skillPath)).toBe(true);
-    const content = readFileSync(skillPath, "utf-8");
+  it("has health.md command", () => {
+    const cmdPath = join(COMMANDS_DIR, "health.md");
+    expect(existsSync(cmdPath)).toBe(true);
+    const content = readFileSync(cmdPath, "utf-8");
     expect(content).toMatch(/^---\n/);
     expect(content).toMatch(/name:\s*health/);
     expect(content).toMatch(/description:/);


### PR DESCRIPTION
## Summary

ACM プラグインの `skills/<name>/SKILL.md` 配置を `commands/*.md` 配置に移行し、slash command dropdown の表示を `/report` → `/acm:report` に修正。

## Why

empirical 観測で判明:
- CVI (`commands/*.md`) → dropdown `/cvi:lang` (prefix 付き) ✅
- ACM (`skills/<name>/SKILL.md`) → dropdown `/report` (prefix なし) ❌

同一 plugin 内の skill 登録はどちらも `plugin:name` namespace で行われるが、slash command palette への登録時に `commands/` 由来は prefix 保持、`skills/` 由来は prefix 省略される（公式 docs に明記なし、実機観測）。

`report` と `health` は MCP tool (`acm_report`, `acm_health`) を叩く単純 wrapper で、scripts や reference ファイルは不要 → `commands/` flat 配置が最小解（karpathy-guidelines 準拠）。

## Changes

- `skills/report/SKILL.md` → `commands/report.md`
- `skills/health/SKILL.md` → `commands/health.md`
- `.claude-plugin/plugin.json` から冗長な `"skills": "./skills"` を除去（commands/ は auto-discovery）
- `user-invocable: true` を除去（デフォルト true）
- `tests/plugin-structure.test.ts` を commands 構造に更新
- `docs/SPECIFICATION.md` のパス参照更新
- `docs/research/commands-vs-skills-2026-04-20.md` 新設（使い分け判断基準を明文化）

## Test plan

- [x] `npx vitest run tests/plugin-structure.test.ts` — 8/8 pass
- [ ] 手動検証: `/reload-plugins` → `/acm` typed で dropdown に `/acm:report` `/acm:health` が prefix 付きで表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)