### PR TITLE
fix(plugin): drop explicit name field so dropdown shows /acm:report

### DIFF
--- a/commands/health.md
+++ b/commands/health.md
@@ -1,5 +1,4 @@
 ---
-name: health
 description: Check ACM MCP server health status (version, timestamp).
 ---
 

--- a/commands/report.md
+++ b/commands/report.md
@@ -1,5 +1,4 @@
 ---
-name: report
 description: Generate a cross-project ACM analysis report showing usage statistics and injection-to-outcome episodes.
 ---
 

--- a/docs/research/commands-vs-skills-2026-04-20.md
+++ b/docs/research/commands-vs-skills-2026-04-20.md
@@ -1,11 +1,16 @@
 # Research: `commands/` vs `skills/` in Claude Code plugins
 
 ## Research Date
-2026-04-20
+2026-04-20（修正版）
 
 ## Research Purpose
 
-ACM プラグインで slash command を `/acm:report` / `/acm:health` の形で autocomplete dropdown に表示させたい。`skills/` 配置では `/report` `/health` と prefix 無しで表示されてしまう。`commands/` と `skills/` の使い分けのベストプラクティスを明文化する。
+ACM プラグインで slash command を `/acm:report` / `/acm:health` の形（plugin namespace prefix 付き）で autocomplete dropdown に表示させたい。実測では `/report` `/health` と prefix 無しで表示されていた。原因究明と、`commands/` と `skills/` の使い分けのベストプラクティスを明文化する。
+
+## 経緯
+
+- 2026-04-16 `bab32e2`（branch `chore/plugin-cleanup-and-research`, unmerged）: 「skills/ → commands/ に移行」と commit メッセージに記録。当時も本件を調査しており、layout 移行が主要因と推定して作業したが main にはマージされなかった
+- 2026-04-20 本リサーチ: 同じ事象を再調査。**真の原因は layout ではなく frontmatter の `name:` フィールド**と判明
 
 ## Research Method
 
@@ -13,32 +18,36 @@ ACM プラグインで slash command を `/acm:report` / `/acm:health` の形で
   - https://code.claude.com/docs/en/plugins-reference
   - https://code.claude.com/docs/en/skills
 - 実機観測（empirical）:
-  - CVI プラグイン（`commands/*.md` 配置）: dropdown が `/cvi:lang` 等 prefix 付き
-  - ACM プラグイン（`skills/<name>/SKILL.md` 配置）: dropdown が `/report` 等 prefix 無し
-- 他プラグインの layout 確認:
-  - `code` plugin は `commands/` と `skills/` 両方配置（同名、hybrid pattern）
+  - CVI プラグイン（`commands/*.md`、`name:` **省略**）: dropdown が `/cvi:lang` 等 prefix 付き ✅
+  - ACM プラグイン（`commands/*.md`、`name: report` **明示**）: dropdown が `/report` prefix 無し ❌
+  - ACM から `name:` を除去すると `/acm:report` 表示に切り替わった ✅
+- 他プラグインの layout 比較:
+  - `code` plugin は `commands/` と `skills/` 両方配置（hybrid pattern）
   - `cvi` plugin は `commands/*.md` 主体、`skills/voice-integration/SKILL.md` は model-invocable background skill
 
-## Summary of Findings
+## 真の原因（2026-04-20 確定）
 
-### 公式 docs の建前
+**frontmatter に `name:` を明示すると plugin namespace prefix が剥がれる**。
+
+| 設定 | dropdown 表示 |
+|---|---|
+| `name: report` 明示 | `/report`（prefix 無し）|
+| `name:` 省略（filename から auto-derive）| `/acm:report`（prefix 付き）|
+
+公式 docs（Skills > Frontmatter reference）:
+> `name` — Display name for the skill. **If omitted, uses the directory name.** Lowercase letters, numbers, and hyphens only (max 64 characters).
+
+→ `name` を明示すると**完全な invocation name**として扱われ、plugin namespace は適用されない。filename（または skills の場合 directory 名）から auto-derive させれば plugin 名が prefix として付与される。
+
+**推奨**: plugin 配下の commands/skills では `name:` を省略する。CVI, code 等の実運用プラグインはこのプラクティスに従っている。
+
+## 補足: 公式 docs 上の `commands/` vs `skills/`
 
 > Custom commands have been merged into skills. A file at `.claude/commands/deploy.md` and a skill at `.claude/skills/deploy/SKILL.md` both create `/deploy` and work the same way.
 >
-> ... commands/ is the legacy format. Use skills/ for new plugins.
+> Commands — Skills as flat Markdown files. Use `skills/` for new plugins
 
-機能上は skills の superset という立て付け。
-
-### 実機観測での差異
-
-公式 docs にない **dropdown 表示挙動の差**:
-
-| Layout | Dropdown 表示例 |
-|---|---|
-| `commands/lang.md` | `/cvi:lang`（prefix 付き） |
-| `skills/report/SKILL.md` | `/report`（prefix 無し） |
-
-同一 plugin 内の skill 登録はどちらも `plugin:name` namespace で行われる（system-reminder の skill 一覧や Skill tool 呼び出しでは両方 prefix 付き）が、**slash command palette への登録時に `commands/` 由来は prefix 保持、`skills/` 由来は prefix 省略**される。
+公式は skills を新規推奨、commands は legacy format と位置付ける。ただし機能・display 挙動は等価（`name:` の挙動も同じ）。
 
 ### 機能比較
 
@@ -52,7 +61,7 @@ ACM プラグインで slash command を `/acm:report` / `/acm:health` の形で
 | `context: fork` サブエージェント実行 | ✅ | ✅ |
 | `` !`command` `` dynamic context injection | ✅ | ✅ |
 | 多ファイル segment load | ❌ | ✅ |
-| **dropdown 表示** | **`/plugin:name` prefix 付き** | **prefix 無し** |
+| dropdown 表示 prefix | `name:` 省略で付く | `name:` 省略で付く |
 
 ## 使い分けの判断基準
 
@@ -60,7 +69,6 @@ ACM プラグインで slash command を `/acm:report` / `/acm:health` の形で
 
 - 単発の slash action（`/commit`, `/deploy`, `/report` のようなボタン感覚）
 - 供給ファイル（script, template, reference.md 等）不要
-- **dropdown に `/plugin:name` で prefix 込みで見せたい**
 - backward compat を気にする
 
 ### `skills/<name>/SKILL.md` を選ぶケース
@@ -68,33 +76,33 @@ ACM プラグインで slash command を `/acm:report` / `/acm:health` の形で
 - Python / bash script を同梱する（例: PDF processor, codebase visualizer）
 - 長大な reference material を progressive に load したい
 - 複数ファイルで構成される複雑な workflow
-- model による自動呼び出しが主目的で dropdown 表示は二次的
+- 公式推奨の新規フォーマット
 
 ### `commands/` + `skills/` 両方置くケース（`code` plugin 方式）
 
 - 共存可能（同名でも問題なし、slash 命名空間は共有）
-- `commands/` が dropdown 表示を担当、`skills/` が model-invocation + 拡張機能を担当
+- `commands/` が slash invocation、`skills/` が model-invocation + 拡張機能
 - **最もリッチ**だが重複管理コストあり
-- 判断が難しい場合の「逃げ道」として有用
 
 ## 結論（ACM の場合）
 
-`acm:report` と `acm:health` は MCP tool を叩く単純 wrapper。scripts 不要、reference 不要、動的 context 注入不要 → **`commands/*.md` 一択**。
+`acm:report` と `acm:health` は MCP tool を叩く単純 wrapper。scripts 不要、reference 不要、動的 context 注入不要 → **`commands/*.md` + `name:` 省略**が最小解。
 
-将来 supporting files が必要になったら `skills/` に昇格、もしくは Code plugin 方式で両方併設に移行可能。
+- PR #123: `skills/` → `commands/` 移行（layout）
+- PR #124: frontmatter から `name:` 除去（真の修正）
 
-## リスクと注意
+## 再発防止 / 作業時の注意
 
-- `commands/` は公式 docs 上は「legacy format」表記。将来的に廃止される可能性がゼロではない
-- ただし現状 Claude Code 本体でサポートは継続しており、実プラグイン（CVI, Code 等公式周辺）で広く使われている
-- 廃止アナウンスが出たら `skills/` 側の dropdown 表示が改善されているはずなので、その時点で再移行すればよい
+- plugin 配下の `commands/*.md` / `skills/*/SKILL.md` では **`name:` を省略**する。filename / directory 名で auto-derive させる
+- `tests/plugin-structure.test.ts` で `name:` 不在を assert することで意図を固定
+- 旧 `skills/` cache が残存していると reload しても挙動が混ざる場合がある（今回の事象）。`/utils:clear-plugin-cache <plugin> -y --marketplace <marketplace>` で cache を明示削除し Claude Code を**完全再起動**する
 
 ## 参考: 実際の plugin での選択例
 
-| Plugin | `commands/` | `skills/` | 方針 |
-|---|---|---|---|
-| `cvi` | ✅（9 files）| ✅（1 background skill）| commands 主体、skills は model-invocable background |
-| `code` | ✅（10 files）| ✅（10 同名）| hybrid（両方）|
-| `ypm` | ✅ | （要確認）| commands 主体 |
-| `acm`（本 PR 以前）| ❌ | ✅（2 files）| skills 単体 → dropdown prefix 無し問題 |
-| `acm`（本 PR 以後）| ✅（2 files）| ❌ | commands 単体 → dropdown prefix あり |
+| Plugin | `commands/` | `skills/` | `name:` 明示 | dropdown |
+|---|---|---|---|---|
+| `cvi` | ✅（9 files）| ✅（1 background skill）| ❌ 省略 | `/cvi:*` ✅ |
+| `code` | ✅（10 files）| ✅（10 同名）| ❌ 省略 | `/code:*` ✅ |
+| `ypm` | ✅ | （要確認）| （要確認）| `/ypm:*` ✅ |
+| `acm`（PR #124 以前）| ✅ | ❌ | ✅ 明示 | `/report` ❌ |
+| `acm`（PR #124 以後）| ✅ | ❌ | ❌ 省略 | `/acm:*` ✅ |

--- a/tests/plugin-structure.test.ts
+++ b/tests/plugin-structure.test.ts
@@ -91,9 +91,11 @@ describe("commands", () => {
     const cmdPath = join(COMMANDS_DIR, "report.md");
     expect(existsSync(cmdPath)).toBe(true);
     const content = readFileSync(cmdPath, "utf-8");
-    // Frontmatter check
+    // Frontmatter check — intentionally omits `name:` so Claude Code derives
+    // it from the filename and applies the plugin namespace prefix (`/acm:report`).
+    // See docs/research/commands-vs-skills-2026-04-20.md.
     expect(content).toMatch(/^---\n/);
-    expect(content).toMatch(/name:\s*report/);
+    expect(content).not.toMatch(/^name:/m);
     expect(content).toMatch(/description:/);
     // Should reference acm_report MCP tool
     expect(content).toContain("acm_report");
@@ -104,7 +106,7 @@ describe("commands", () => {
     expect(existsSync(cmdPath)).toBe(true);
     const content = readFileSync(cmdPath, "utf-8");
     expect(content).toMatch(/^---\n/);
-    expect(content).toMatch(/name:\s*health/);
+    expect(content).not.toMatch(/^name:/m);
     expect(content).toMatch(/description:/);
     // Should reference acm_health MCP tool
     expect(content).toContain("acm_health");


### PR DESCRIPTION
## Summary

ACM の `commands/report.md` / `commands/health.md` frontmatter から `name: report` / `name: health` を除去。

## Why

PR #123 で `commands/` 配置に移行したが、dropdown は依然 `/report` `/health` を表示していた。実機比較で判明:

- CVI `commands/lang.md`: `name:` **無し** → `/cvi:lang`（prefix 付き）✅
- ACM `commands/report.md`: `name: report` **明示** → `/report`（prefix 無し）❌

公式 skills docs より:
> `name` — Display name for the skill. If omitted, uses the directory name.

`name` を明示すると**完全な invocation name**として扱われ plugin namespace が適用されない。filename から auto-derive させれば `acm:` prefix が付与される。

## Changes

- `commands/report.md` から `name: report` 除去
- `commands/health.md` から `name: health` 除去
- `tests/plugin-structure.test.ts` を `name:` 欠如を assert する形に更新
- `docs/research/commands-vs-skills-2026-04-20.md` にこの追加発見を記載

## Test plan

- [x] `npx vitest run tests/plugin-structure.test.ts` — 8/8 pass
- [ ] 手動検証: `/reload-plugins` → `/acm` typed で `/acm:report` `/acm:health` が prefix 付きで表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)