### PR TITLE
feat(acm): inject corrective instruction bodies for high-strength entries

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -205,7 +205,11 @@ Layer 3: JSONL files      → Operational logs / debugging (this section)
 Past relevant experience:
 - SUCCESS: {trigger} → {outcome} (strength: {score})
 - FAILURE: {trigger} → {outcome}, user feedback: "{dialogue_summary}" (strength: {score})
+    • "{corrective body 1}"
+    • "{corrective body 2}"
 ```
+
+**Corrective body inlining (#128)**: For `FAILURE` entries with `corrective_bodies` populated, raw corrective instruction texts are inlined under the entry when `score ≥ INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD` (default `0.6`). Up to `MAX_INLINED_BODIES_PER_ENTRY` (default `3`) bodies are shown. This surfaces the verbatim user feedback so the LLM can act on specifics rather than a summary count. Inlined bodies are informational context, not imperative rules. Policy exposure via `userConfig` is deferred to #130.
 
 ### 3.2 PostToolUseFailure Hook
 
@@ -291,6 +295,7 @@ Past relevant experience:
    - If `corrective_instructions > 0`: generate failure entry (corrective-driven)
      - If also interrupted: use `interrupt_with_dialogue` signal type, add interrupt_context
      - If not interrupted: use `corrective_instruction` signal type
+     - Populate `corrective_bodies` with up to 5 raw corrective prompts (each truncated to 200 chars) for later body inlining at injection (Section 3.1, #128)
    - If `interrupted && corrective_instructions == 0`: ambiguous — no entry generated
    - If `!interrupted && corrective_instructions == 0`: generate success entry
 8. Generate retrieval keys from session content (keyword extraction)

--- a/src/experience/generator.ts
+++ b/src/experience/generator.ts
@@ -68,7 +68,9 @@ export class ExperienceGenerator {
       const signalType = summary.was_interrupted
         ? "interrupt_with_dialogue"
         : "corrective_instruction";
-      const correctiveBodies = this.buildCorrectiveBodies(idx);
+      const correctiveBodies = summary.was_interrupted
+        ? undefined
+        : this.buildCorrectiveBodies(idx);
       results.push({
         type: "failure",
         trigger: this.buildTrigger(idx, context),
@@ -213,7 +215,9 @@ export class ExperienceGenerator {
     for (const c of corrections.slice(0, MAX_CORRECTIVE_BODIES_PER_ENTRY)) {
       const p = c.data?.prompt;
       if (typeof p === "string" && p.trim()) {
-        bodies.push(p.slice(0, MAX_CORRECTIVE_BODY_CHARS));
+        // Collapse newlines: raw user text is inlined into LLM context, and multi-line
+        // bodies could be mistaken for structural context by a credulous reader.
+        bodies.push(p.slice(0, MAX_CORRECTIVE_BODY_CHARS).replace(/\s*\n\s*/g, " "));
       }
     }
     return bodies.length > 0 ? bodies : undefined;

--- a/src/experience/generator.ts
+++ b/src/experience/generator.ts
@@ -11,6 +11,9 @@ import type { EventType, SessionSignal } from "../signals/types.js";
 import { computeFailureStrength, computeSuccessStrength } from "./scoring.js";
 import { extractRetrievalKeys } from "./keywords.js";
 
+const MAX_CORRECTIVE_BODIES_PER_ENTRY = 5;
+const MAX_CORRECTIVE_BODY_CHARS = 200;
+
 export interface GenerationInput {
   session_id: string;
   summary: SessionSummary;
@@ -65,6 +68,7 @@ export class ExperienceGenerator {
       const signalType = summary.was_interrupted
         ? "interrupt_with_dialogue"
         : "corrective_instruction";
+      const correctiveBodies = this.buildCorrectiveBodies(idx);
       results.push({
         type: "failure",
         trigger: this.buildTrigger(idx, context),
@@ -76,6 +80,7 @@ export class ExperienceGenerator {
         session_id,
         timestamp,
         ...(summary.was_interrupted ? { interrupt_context: this.buildInterruptContext(idx) } : {}),
+        ...(correctiveBodies ? { corrective_bodies: correctiveBodies } : {}),
       });
     }
 
@@ -199,6 +204,19 @@ export class ExperienceGenerator {
     return idx.hasTestPass
       ? "Task completed with passing tests"
       : "Task completed without test verification";
+  }
+
+  private buildCorrectiveBodies(idx: SignalIndex): string[] | undefined {
+    const corrections = idx.byType.get("corrective_instruction") ?? [];
+    if (corrections.length === 0) return undefined;
+    const bodies: string[] = [];
+    for (const c of corrections.slice(0, MAX_CORRECTIVE_BODIES_PER_ENTRY)) {
+      const p = c.data?.prompt;
+      if (typeof p === "string" && p.trim()) {
+        bodies.push(p.slice(0, MAX_CORRECTIVE_BODY_CHARS));
+      }
+    }
+    return bodies.length > 0 ? bodies : undefined;
   }
 
   private buildInterruptContext(idx: SignalIndex): ExperienceEntry["interrupt_context"] {

--- a/src/retrieval/injector.ts
+++ b/src/retrieval/injector.ts
@@ -8,6 +8,12 @@ import type { RetrievalResult } from "./types.js";
 const HEADER = "[ACM Context]\nPast relevant experience:";
 const TOKEN_BUDGET_CHARS = 2000; // ~500 tokens at 4 chars/token
 
+// High-strength entries get their corrective instruction bodies inlined.
+// See docs/SPECIFICATION.md Section 3.1. Threshold is on `score` (includes retrieval boost),
+// not raw signal_strength. Policy surface deferred to #130.
+export const INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD = 0.6;
+export const MAX_INLINED_BODIES_PER_ENTRY = 3;
+
 export function formatInjection(results: RetrievalResult[]): string {
   if (results.length === 0) return "";
 
@@ -16,22 +22,31 @@ export function formatInjection(results: RetrievalResult[]): string {
 
   for (const { entry, score } of results) {
     const scoreStr = score.toFixed(2);
-    let line: string;
+    let block: string;
 
     if (entry.type === "success") {
-      line = `- SUCCESS: ${entry.trigger} → ${entry.outcome} (strength: ${scoreStr})`;
+      block = `- SUCCESS: ${entry.trigger} → ${entry.outcome} (strength: ${scoreStr})`;
     } else {
       const feedback = entry.interrupt_context?.dialogue_summary;
-      if (feedback) {
-        line = `- FAILURE: ${entry.trigger} → ${entry.outcome}, user feedback: "${feedback}" (strength: ${scoreStr})`;
+      const header = feedback
+        ? `- FAILURE: ${entry.trigger} → ${entry.outcome}, user feedback: "${feedback}" (strength: ${scoreStr})`
+        : `- FAILURE: ${entry.trigger} → ${entry.outcome} (strength: ${scoreStr})`;
+
+      const bodies = entry.corrective_bodies;
+      const shouldInline =
+        bodies && bodies.length > 0 && score >= INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD;
+
+      if (shouldInline) {
+        const bodyLines = bodies.slice(0, MAX_INLINED_BODIES_PER_ENTRY).map((b) => `    • "${b}"`);
+        block = [header, ...bodyLines].join("\n");
       } else {
-        line = `- FAILURE: ${entry.trigger} → ${entry.outcome} (strength: ${scoreStr})`;
+        block = header;
       }
     }
 
-    const blockLen = line.length + 1;
+    const blockLen = block.length + 1;
     if (totalChars + blockLen > TOKEN_BUDGET_CHARS) break;
-    lines.push(line);
+    lines.push(block);
     totalChars += blockLen;
   }
 

--- a/src/store/experience-store.ts
+++ b/src/store/experience-store.ts
@@ -54,8 +54,8 @@ export class ExperienceStore {
       `INSERT INTO experiences
        (id, type, trigger_text, action_text, outcome_text,
         retrieval_keys, signal_strength, signal_type,
-        session_id, timestamp, interrupt_context, embedding, project)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        session_id, timestamp, interrupt_context, embedding, project, corrective_bodies)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     );
     this.stmtGetById = this.db.prepare("SELECT * FROM experiences WHERE id = ?");
     this.stmtList = this.db.prepare("SELECT * FROM experiences ORDER BY timestamp DESC LIMIT ?");
@@ -425,7 +425,10 @@ export class ExperienceStore {
       entry.timestamp,
       entry.interrupt_context ? JSON.stringify(entry.interrupt_context) : null,
       embeddingBlob,
-      entry.project ?? null
+      entry.project ?? null,
+      entry.corrective_bodies && entry.corrective_bodies.length > 0
+        ? JSON.stringify(entry.corrective_bodies)
+        : null
     );
 
     return entry;
@@ -575,6 +578,9 @@ export class ExperienceStore {
           : undefined,
       };
       if (row.project) entry.project = row.project as string;
+      if (row.corrective_bodies) {
+        entry.corrective_bodies = JSON.parse(row.corrective_bodies as string) as string[];
+      }
       if (row.last_retrieved_at) entry.last_retrieved_at = row.last_retrieved_at as string;
       if (row.retrieval_count != null) entry.retrieval_count = row.retrieval_count as number;
       if (row.feedback_score != null) entry.feedback_score = row.feedback_score as number;

--- a/src/store/experience-store.ts
+++ b/src/store/experience-store.ts
@@ -579,7 +579,20 @@ export class ExperienceStore {
       };
       if (row.project) entry.project = row.project as string;
       if (row.corrective_bodies) {
-        entry.corrective_bodies = JSON.parse(row.corrective_bodies as string) as string[];
+        try {
+          const parsed = JSON.parse(row.corrective_bodies as string);
+          if (Array.isArray(parsed)) {
+            entry.corrective_bodies = parsed as string[];
+          } else {
+            console.warn(
+              `[ACM] corrective_bodies is not an array for entry id="${id}", skipping field`
+            );
+          }
+        } catch (err) {
+          console.warn(
+            `[ACM] Failed to parse corrective_bodies for entry id="${id}": ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
       }
       if (row.last_retrieved_at) entry.last_retrieved_at = row.last_retrieved_at as string;
       if (row.retrieval_count != null) entry.retrieval_count = row.retrieval_count as number;

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -75,10 +75,25 @@ function migrateDatabase(db: AdaptedDatabase): void {
     { name: "archived_at", definition: "TEXT" },
     { name: "corrective_bodies", definition: "TEXT" },
   ];
-  for (const col of gcColumns) {
-    if (!columnNames.has(col.name)) {
-      db.exec(`ALTER TABLE experiences ADD COLUMN ${col.name} ${col.definition}`);
+  db.exec("BEGIN");
+  try {
+    for (const col of gcColumns) {
+      if (!columnNames.has(col.name)) {
+        db.exec(`ALTER TABLE experiences ADD COLUMN ${col.name} ${col.definition}`);
+      }
     }
+    db.exec("COMMIT");
+  } catch (err) {
+    try {
+      db.exec("ROLLBACK");
+    } catch (rollbackErr) {
+      console.error(
+        `[ACM] migrateDatabase: ROLLBACK failed during gcColumns migration. ` +
+          `Original: ${err instanceof Error ? err.message : String(err)}. ` +
+          `ROLLBACK: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`
+      );
+    }
+    throw err;
   }
   db.exec("CREATE INDEX IF NOT EXISTS idx_experiences_archived ON experiences(archived_at)");
 

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -22,7 +22,8 @@ CREATE TABLE IF NOT EXISTS experiences (
   retrieval_count INTEGER NOT NULL DEFAULT 0,
   feedback_score INTEGER NOT NULL DEFAULT 0,
   pinned INTEGER NOT NULL DEFAULT 0,
-  archived_at TEXT
+  archived_at TEXT,
+  corrective_bodies TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_experiences_type
@@ -72,6 +73,7 @@ function migrateDatabase(db: AdaptedDatabase): void {
     { name: "feedback_score", definition: "INTEGER NOT NULL DEFAULT 0" },
     { name: "pinned", definition: "INTEGER NOT NULL DEFAULT 0" },
     { name: "archived_at", definition: "TEXT" },
+    { name: "corrective_bodies", definition: "TEXT" },
   ];
   for (const col of gcColumns) {
     if (!columnNames.has(col.name)) {
@@ -93,7 +95,7 @@ function migrateDatabase(db: AdaptedDatabase): void {
         `INSERT INTO experiences SELECT id, type, trigger_text, action_text, outcome_text,
           retrieval_keys, signal_strength, signal_type, session_id, timestamp,
           interrupt_context, embedding, project, last_retrieved_at, retrieval_count,
-          feedback_score, pinned, archived_at
+          feedback_score, pinned, archived_at, corrective_bodies
         FROM experiences_old`
       );
       db.exec("DROP TABLE experiences_old");

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -37,6 +37,7 @@ export interface ExperienceEntry {
   timestamp: string; // ISO 8601
   project?: string; // Project name (derived from cwd basename)
   interrupt_context?: InterruptContext; // Failure-specific
+  corrective_bodies?: string[]; // Raw corrective instruction texts (truncated, capped count). Populated for corrective-driven failures.
 
   // GC / recency tracking fields (SPECIFICATION Section 4.4)
   last_retrieved_at?: string; // ISO 8601, updated on retrieval

--- a/tests/experience/generator.test.ts
+++ b/tests/experience/generator.test.ts
@@ -303,6 +303,47 @@ describe("ExperienceGenerator", () => {
       expect(failure!.corrective_bodies).not.toContain("sixth (dropped)");
     });
 
+    it("does NOT populate corrective_bodies when was_interrupted=true (#128)", () => {
+      const summary = makeSummary({
+        was_interrupted: true,
+        corrective_instruction_count: 2,
+        counts: {
+          ...makeSummary().counts,
+          interrupt: 1,
+          post_interrupt_turn: 1,
+          corrective_instruction: 2,
+        },
+        total_signals: 4,
+      });
+      const signals: SessionSignal[] = [
+        makeSignal("interrupt", { tool_name: "Bash", error: "x" }),
+        makeSignal("post_interrupt_turn", { prompt: "stop" }),
+        makeSignal("corrective_instruction", { prompt: "fix this", pattern: "p" }),
+        makeSignal("corrective_instruction", { prompt: "not that", pattern: "p" }),
+      ];
+      const result = generator.generate({ session_id: "s", summary, signals });
+      const failure = result.find((e) => e.type === "failure");
+      expect(failure?.corrective_bodies).toBeUndefined();
+    });
+
+    it("collapses newlines in corrective body text (#128)", () => {
+      const summary = makeSummary({
+        corrective_instruction_count: 1,
+        counts: { ...makeSummary().counts, corrective_instruction: 1 },
+        total_signals: 1,
+      });
+      const signals: SessionSignal[] = [
+        makeSignal("corrective_instruction", {
+          prompt: "first line\n  second line\nthird",
+          pattern: "p",
+        }),
+      ];
+      const result = generator.generate({ session_id: "s", summary, signals });
+      const failure = result.find((e) => e.type === "failure");
+      expect(failure?.corrective_bodies?.[0]).toBe("first line second line third");
+      expect(failure?.corrective_bodies?.[0]).not.toContain("\n");
+    });
+
     it("populates interrupt_context for interrupt + corrective failure", () => {
       const summary = makeSummary({
         was_interrupted: true,

--- a/tests/experience/generator.test.ts
+++ b/tests/experience/generator.test.ts
@@ -276,6 +276,33 @@ describe("ExperienceGenerator", () => {
       expect(result[0].action).toContain("Edit");
     });
 
+    it("populates corrective_bodies with truncated raw prompts (#128)", () => {
+      const longPrompt = "X".repeat(500);
+      const summary = makeSummary({
+        corrective_instruction_count: 6,
+        counts: { ...makeSummary().counts, corrective_instruction: 6 },
+        total_signals: 6,
+      });
+      const signals: SessionSignal[] = [
+        makeSignal("corrective_instruction", { prompt: "first", pattern: "p" }),
+        makeSignal("corrective_instruction", { prompt: "second", pattern: "p" }),
+        makeSignal("corrective_instruction", { prompt: longPrompt, pattern: "p" }),
+        makeSignal("corrective_instruction", { prompt: "fourth", pattern: "p" }),
+        makeSignal("corrective_instruction", { prompt: "fifth", pattern: "p" }),
+        makeSignal("corrective_instruction", { prompt: "sixth (dropped)", pattern: "p" }),
+      ];
+
+      const result = generator.generate({ session_id: "s", summary, signals });
+      const failure = result.find((e) => e.type === "failure");
+      expect(failure?.corrective_bodies).toBeDefined();
+      expect(failure!.corrective_bodies!.length).toBeLessThanOrEqual(5);
+      expect(failure!.corrective_bodies![0]).toBe("first");
+      // Truncated body does not exceed max chars
+      expect(failure!.corrective_bodies!.every((b) => b.length <= 200)).toBe(true);
+      // Sixth dropped
+      expect(failure!.corrective_bodies).not.toContain("sixth (dropped)");
+    });
+
     it("populates interrupt_context for interrupt + corrective failure", () => {
       const summary = makeSummary({
         was_interrupted: true,

--- a/tests/retrieval/injector.test.ts
+++ b/tests/retrieval/injector.test.ts
@@ -146,6 +146,25 @@ describe("formatInjection", () => {
     expect(matches.length).toBeLessThanOrEqual(3);
   });
 
+  it("respects budget when entries have inlined corrective bodies (#128)", () => {
+    const bigBodies = Array.from({ length: 3 }, () => "X".repeat(200));
+    const results: RetrievalResult[] = [];
+    for (let i = 0; i < 20; i++) {
+      results.push(
+        makeResult({
+          type: "failure",
+          signal_type: "corrective_instruction",
+          trigger: "T".repeat(50),
+          outcome: "O".repeat(50),
+          corrective_bodies: bigBodies,
+          score: 1.2 - i * 0.01,
+        })
+      );
+    }
+    const text = formatInjection(results);
+    expect(text.length).toBeLessThanOrEqual(2000);
+  });
+
   it("truncates to 500 token budget (approx 2000 chars)", () => {
     const longResults: RetrievalResult[] = [];
     for (let i = 0; i < 20; i++) {

--- a/tests/retrieval/injector.test.ts
+++ b/tests/retrieval/injector.test.ts
@@ -100,6 +100,52 @@ describe("formatInjection", () => {
     expect(lines[1]).toContain("FAILURE:");
   });
 
+  it("inlines corrective bodies when score meets threshold (#128)", () => {
+    const result = formatInjection([
+      makeResult({
+        type: "failure",
+        signal_type: "corrective_instruction",
+        signal_strength: 0.8,
+        corrective_bodies: [
+          "ビルトインコマンドはそのまま使ったほうが良くない？",
+          "setting.local.jsonで修正してもいい。",
+        ],
+        score: 1.2,
+      }),
+    ]);
+    expect(result).toContain('    • "ビルトインコマンドはそのまま使ったほうが良くない？"');
+    expect(result).toContain('    • "setting.local.jsonで修正してもいい。"');
+  });
+
+  it("omits corrective bodies when score is below threshold (#128)", () => {
+    const result = formatInjection([
+      makeResult({
+        type: "failure",
+        signal_type: "corrective_instruction",
+        signal_strength: 0.4,
+        corrective_bodies: ["some instruction"],
+        score: 0.3,
+      }),
+    ]);
+    expect(result).not.toContain('"some instruction"');
+    expect(result).toContain("FAILURE:");
+  });
+
+  it("caps inlined bodies to MAX_INLINED_BODIES_PER_ENTRY (#128)", () => {
+    const bodies = Array.from({ length: 10 }, (_, i) => `body-${i}`);
+    const result = formatInjection([
+      makeResult({
+        type: "failure",
+        signal_type: "corrective_instruction",
+        signal_strength: 0.9,
+        corrective_bodies: bodies,
+        score: 1.5,
+      }),
+    ]);
+    const matches = result.match(/• "body-\d+"/g) ?? [];
+    expect(matches.length).toBeLessThanOrEqual(3);
+  });
+
   it("truncates to 500 token budget (approx 2000 chars)", () => {
     const longResults: RetrievalResult[] = [];
     for (let i = 0; i < 20; i++) {

--- a/tests/store/experience-store.test.ts
+++ b/tests/store/experience-store.test.ts
@@ -31,6 +31,28 @@ describe("ExperienceStore", () => {
       expect(retrieved?.retrieval_keys).toEqual(["auth", "null-token", "bug-fix"]);
     });
 
+    it("round-trips corrective_bodies for failure entries (#128)", () => {
+      const bodies = ["first instruction", "second instruction"];
+      const entry = store.create(
+        makeEntry({
+          type: "failure",
+          signal_type: "corrective_instruction",
+          signal_strength: 0.8,
+          corrective_bodies: bodies,
+        })
+      );
+      expect(entry).not.toBeNull();
+
+      const retrieved = store.getById(entry!.id);
+      expect(retrieved?.corrective_bodies).toEqual(bodies);
+    });
+
+    it("omits corrective_bodies when absent (#128)", () => {
+      const entry = store.create(makeEntry());
+      const retrieved = store.getById(entry!.id);
+      expect(retrieved?.corrective_bodies).toBeUndefined();
+    });
+
     it("stores interrupt_context for failure entries", () => {
       const entry = store.create(
         makeEntry({


### PR DESCRIPTION
## Summary

Closes #128.

FAILURE エントリの corrective instruction 本体を injection に inline 展開する機能を追加。要約カウント (`Received 16 corrective instructions`) だけでは LLM が次回行動を特定できず、strength 1.48–1.70 の高ランク entry 複数存在下でも同種違反が再発していた (#127 / claude-tools #247 / orbitscore #149) observed bottleneck に対応。

- `ExperienceEntry.corrective_bodies?: string[]` を追加（最大 5 件 × 各 200 chars truncate、改行は空白に畳み込み）
- Generator が **非 interrupted** corrective-driven failure 生成時に raw prompts を populate
- Injector が score ≥ 0.6 の FAILURE に最大 3 件の body を箇条書きで inline
- SQLite 側は additive migration（ALTER TABLE ADD COLUMN）で既存 DB 非破壊
- Threshold / 件数の userConfig 露出は #130 で対応

## Test plan

- [x] `npx vitest run` — 667 tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] 実機で新規 corrective session を発生させ、injection に body lines が出ることを確認
- [ ] sqlite3 で corrective_bodies カラムに JSON 配列が入っていることを確認

## Non-goals

- userConfig 露出（#130）
- decision-point 再 retrieve（#129）
- 既存 DB entry の backfill（新規 entry のみ populate）
- source: user_invoked capture tagging（別 issue 系列）

🤖 Generated with [Claude Code](https://claude.com/claude-code)