### PR TITLE
feat(acm): expose injection policy via userConfig and log entry rationale

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -34,6 +34,16 @@
       "type": "number",
       "title": "Max Experiences Per Project",
       "description": "Maximum experience entries per project before GC triggers (default: 500)"
+    },
+    "inject_corrective_bodies_score_threshold": {
+      "type": "number",
+      "title": "Corrective Body Inline Score Threshold",
+      "description": "Minimum retrieval score for inlining raw corrective instruction bodies into the FAILURE entry in session injection (default: 0.6; valid range 0.0–5.0 since the score includes retrieval boost and can exceed 1.0). Lower values surface more instructions; higher values restrict to top-ranked entries."
+    },
+    "inject_corrective_bodies_max": {
+      "type": "number",
+      "title": "Max Inlined Bodies Per Entry",
+      "description": "Maximum number of raw corrective instructions shown inline under each FAILURE entry (default: 3)."
     }
   }
 }

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -209,7 +209,9 @@ Past relevant experience:
     • "{corrective body 2}"
 ```
 
-**Corrective body inlining (#128)**: For `FAILURE` entries with `corrective_bodies` populated, raw corrective instruction texts are inlined under the entry when `score ≥ INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD` (default `0.6`). Up to `MAX_INLINED_BODIES_PER_ENTRY` (default `3`) bodies are shown. This surfaces the verbatim user feedback so the LLM can act on specifics rather than a summary count. Inlined bodies are informational context, not imperative rules. Policy exposure via `userConfig` is deferred to #130.
+**Corrective body inlining (#128, #130)**: For `FAILURE` entries with `corrective_bodies` populated, raw corrective instruction texts are inlined under the entry when `score ≥ inject_corrective_bodies_score_threshold` (default `0.6`). Up to `inject_corrective_bodies_max` bodies (default `3`) are shown. Both thresholds are exposed as `userConfig` entries (`CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD` / `_MAX`). Inlined bodies are informational context, not imperative rules.
+
+**Injection rationale log (#130)**: Each `injection` event recorded in `session_signals` includes an `entry_rationale` array with `{ id, score, bodies_inlined }` per selected entry. This allows observers to reconstruct *why* each entry was selected (score) and whether its corrective body was shown, without re-running retrieval.
 
 ### 3.2 PostToolUseFailure Hook
 

--- a/src/hooks/_common.ts
+++ b/src/hooks/_common.ts
@@ -86,7 +86,7 @@ export function applyPluginOptionOverrides(config: AcmConfig): void {
   }
 
   const bodyMax = process.env.CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_MAX?.trim();
-  if (bodyMax) {
+  if (bodyMax !== undefined && bodyMax !== "") {
     const n = Number(bodyMax);
     if (Number.isInteger(n) && n >= 1 && n <= 10) {
       config.inject_corrective_bodies_max = n;

--- a/src/hooks/_common.ts
+++ b/src/hooks/_common.ts
@@ -68,6 +68,33 @@ export function applyPluginOptionOverrides(config: AcmConfig): void {
       );
     }
   }
+
+  const bodyThreshold =
+    process.env.CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD?.trim();
+  if (bodyThreshold) {
+    const n = Number(bodyThreshold);
+    if (Number.isFinite(n) && n >= 0 && n <= 5) {
+      config.inject_corrective_bodies_score_threshold = n;
+    } else {
+      console.error(
+        `[ACM] CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD: invalid value "${bodyThreshold}". ` +
+          `Expected number in [0, 5]. Using default ${config.inject_corrective_bodies_score_threshold}.`
+      );
+    }
+  }
+
+  const bodyMax = process.env.CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_MAX?.trim();
+  if (bodyMax) {
+    const n = Number(bodyMax);
+    if (Number.isInteger(n) && n >= 1 && n <= 10) {
+      config.inject_corrective_bodies_max = n;
+    } else {
+      console.error(
+        `[ACM] CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_MAX: invalid value "${bodyMax}". ` +
+          `Expected integer in [1, 10]. Using default ${config.inject_corrective_bodies_max}.`
+      );
+    }
+  }
 }
 
 export async function bootstrapHook(stdin: string): Promise<HookContext | null> {

--- a/src/hooks/_common.ts
+++ b/src/hooks/_common.ts
@@ -71,7 +71,9 @@ export function applyPluginOptionOverrides(config: AcmConfig): void {
 
   const bodyThreshold =
     process.env.CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD?.trim();
-  if (bodyThreshold) {
+  // "0" must pass this guard since a zero threshold is a legitimate value
+  // meaning "always inline bodies for failure entries with bodies present".
+  if (bodyThreshold !== undefined && bodyThreshold !== "") {
     const n = Number(bodyThreshold);
     if (Number.isFinite(n) && n >= 0 && n <= 5) {
       config.inject_corrective_bodies_score_threshold = n;

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -11,7 +11,7 @@ import { readFileSync } from "node:fs";
 import { basename } from "node:path";
 import { bootstrapHook, requireInputString, runAsHookScript, type HookContext } from "./_common.js";
 import { Retriever } from "../retrieval/retriever.js";
-import { formatInjection } from "../retrieval/injector.js";
+import { bodiesInlinedFor, formatInjection, type InjectionPolicy } from "../retrieval/injector.js";
 import { formatInjectionMessage } from "./verbosity-formatter.js";
 import type { RetrievalResult } from "../retrieval/types.js";
 
@@ -81,7 +81,11 @@ export function retrieveAndInject(
 ): RetrieveAndInjectResult {
   const retriever = new Retriever(ctx.experienceStore, ctx.config.recency_half_life_days);
   const results = retriever.retrieve(queryEmbedding, ctx.config.top_k);
-  const injectionText = formatInjection(results);
+  const policy: InjectionPolicy = {
+    correctiveBodiesScoreThreshold: ctx.config.inject_corrective_bodies_score_threshold,
+    maxInlinedBodiesPerEntry: ctx.config.inject_corrective_bodies_max,
+  };
+  const injectionText = formatInjection(results, policy);
 
   // Record injection log — best-effort, must not abort injection delivery
   if (results.length > 0) {
@@ -91,6 +95,11 @@ export function retrieveAndInject(
         injected_count: results.length,
         query_text: queryText,
         project: ctx.projectName,
+        entry_rationale: results.map((r) => ({
+          id: r.entry.id,
+          score: Number(r.score.toFixed(3)),
+          bodies_inlined: bodiesInlinedFor(r.entry, r.score, policy),
+        })),
       });
     } catch (err) {
       console.error(

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -89,17 +89,20 @@ export function retrieveAndInject(
 
   // Record injection log — best-effort, must not abort injection delivery
   if (results.length > 0) {
+    // Compute rationale outside try so payload-construction errors surface as their own
+    // stack, not masked as "addSignal failed"
+    const entryRationale = results.map((r) => ({
+      id: r.entry.id,
+      score: Number(r.score.toFixed(3)),
+      bodies_inlined: bodiesInlinedFor(r.entry, r.score, policy),
+    }));
     try {
       ctx.signalStore.addSignal(sessionId, "injection", {
         injected_ids: results.map((r) => r.entry.id),
         injected_count: results.length,
         query_text: queryText,
         project: ctx.projectName,
-        entry_rationale: results.map((r) => ({
-          id: r.entry.id,
-          score: Number(r.score.toFixed(3)),
-          bodies_inlined: bodiesInlinedFor(r.entry, r.score, policy),
-        })),
+        entry_rationale: entryRationale,
       });
     } catch (err) {
       console.error(

--- a/src/retrieval/injector.ts
+++ b/src/retrieval/injector.ts
@@ -3,6 +3,7 @@
  * Formats retrieval results into compact context injection text.
  * Budget: ~500 tokens ≈ 2000 characters.
  */
+import { DEFAULT_CONFIG } from "../store/types.js";
 import type { RetrievalResult } from "./types.js";
 
 const HEADER = "[ACM Context]\nPast relevant experience:";
@@ -14,8 +15,8 @@ export interface InjectionPolicy {
 }
 
 export const DEFAULT_INJECTION_POLICY: InjectionPolicy = {
-  correctiveBodiesScoreThreshold: 0.6,
-  maxInlinedBodiesPerEntry: 3,
+  correctiveBodiesScoreThreshold: DEFAULT_CONFIG.inject_corrective_bodies_score_threshold,
+  maxInlinedBodiesPerEntry: DEFAULT_CONFIG.inject_corrective_bodies_max,
 };
 
 export function formatInjection(
@@ -39,9 +40,10 @@ export function formatInjection(
         ? `- FAILURE: ${entry.trigger} → ${entry.outcome}, user feedback: "${feedback}" (strength: ${scoreStr})`
         : `- FAILURE: ${entry.trigger} → ${entry.outcome} (strength: ${scoreStr})`;
 
-      if (bodiesInlinedFor(entry, score, policy)) {
-        const bodyLines = entry
-          .corrective_bodies!.slice(0, policy.maxInlinedBodiesPerEntry)
+      const bodies = entry.corrective_bodies;
+      if (bodies && bodiesInlinedFor(entry, score, policy)) {
+        const bodyLines = bodies
+          .slice(0, policy.maxInlinedBodiesPerEntry)
           .map((b) => `    • "${b}"`);
         block = [header, ...bodyLines].join("\n");
       } else {
@@ -61,6 +63,11 @@ export function formatInjection(
   return lines.join("\n");
 }
 
+/**
+ * Whether a single entry's corrective bodies should be inlined in injection.
+ * Returns true only for FAILURE entries with populated corrective_bodies
+ * whose retrieval score meets the policy threshold.
+ */
 export function bodiesInlinedFor(
   entry: RetrievalResult["entry"],
   score: number,

--- a/src/retrieval/injector.ts
+++ b/src/retrieval/injector.ts
@@ -8,13 +8,20 @@ import type { RetrievalResult } from "./types.js";
 const HEADER = "[ACM Context]\nPast relevant experience:";
 const TOKEN_BUDGET_CHARS = 2000; // ~500 tokens at 4 chars/token
 
-// High-strength entries get their corrective instruction bodies inlined.
-// See docs/SPECIFICATION.md Section 3.1. Threshold is on `score` (includes retrieval boost),
-// not raw signal_strength. Policy surface deferred to #130.
-export const INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD = 0.6;
-export const MAX_INLINED_BODIES_PER_ENTRY = 3;
+export interface InjectionPolicy {
+  correctiveBodiesScoreThreshold: number;
+  maxInlinedBodiesPerEntry: number;
+}
 
-export function formatInjection(results: RetrievalResult[]): string {
+export const DEFAULT_INJECTION_POLICY: InjectionPolicy = {
+  correctiveBodiesScoreThreshold: 0.6,
+  maxInlinedBodiesPerEntry: 3,
+};
+
+export function formatInjection(
+  results: RetrievalResult[],
+  policy: InjectionPolicy = DEFAULT_INJECTION_POLICY
+): string {
   if (results.length === 0) return "";
 
   const lines: string[] = [HEADER];
@@ -32,12 +39,10 @@ export function formatInjection(results: RetrievalResult[]): string {
         ? `- FAILURE: ${entry.trigger} → ${entry.outcome}, user feedback: "${feedback}" (strength: ${scoreStr})`
         : `- FAILURE: ${entry.trigger} → ${entry.outcome} (strength: ${scoreStr})`;
 
-      const bodies = entry.corrective_bodies;
-      const shouldInline =
-        bodies && bodies.length > 0 && score >= INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD;
-
-      if (shouldInline) {
-        const bodyLines = bodies.slice(0, MAX_INLINED_BODIES_PER_ENTRY).map((b) => `    • "${b}"`);
+      if (bodiesInlinedFor(entry, score, policy)) {
+        const bodyLines = entry
+          .corrective_bodies!.slice(0, policy.maxInlinedBodiesPerEntry)
+          .map((b) => `    • "${b}"`);
         block = [header, ...bodyLines].join("\n");
       } else {
         block = header;
@@ -54,4 +59,14 @@ export function formatInjection(results: RetrievalResult[]): string {
   if (lines.length === 1) return "";
 
   return lines.join("\n");
+}
+
+export function bodiesInlinedFor(
+  entry: RetrievalResult["entry"],
+  score: number,
+  policy: InjectionPolicy
+): boolean {
+  if (entry.type !== "failure") return false;
+  if (!entry.corrective_bodies || entry.corrective_bodies.length === 0) return false;
+  return score >= policy.correctiveBodiesScoreThreshold;
 }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -120,6 +120,8 @@ export interface AcmConfig {
   ollama_model?: string; // Ollama model for corrective classification (default: gemma2:2b)
   max_experiences_per_project: number; // GC capacity limit per project (default: 500)
   recency_half_life_days: number; // Half-life for recency decay in days (default: 30)
+  inject_corrective_bodies_score_threshold: number; // Min retrieval score for inlining corrective bodies (default: 0.6)
+  inject_corrective_bodies_max: number; // Max corrective bodies shown per FAILURE entry (default: 3)
 }
 
 export const DEFAULT_CONFIG: AcmConfig = {
@@ -131,4 +133,6 @@ export const DEFAULT_CONFIG: AcmConfig = {
   verbosity: "normal",
   max_experiences_per_project: 500,
   recency_half_life_days: 30,
+  inject_corrective_bodies_score_threshold: 0.6,
+  inject_corrective_bodies_max: 3,
 };

--- a/tests/hooks/common.test.ts
+++ b/tests/hooks/common.test.ts
@@ -206,6 +206,8 @@ describe("applyPluginOptionOverrides", () => {
     delete process.env.CLAUDE_PLUGIN_OPTION_OLLAMA_MODEL;
     delete process.env.CLAUDE_PLUGIN_OPTION_VERBOSITY;
     delete process.env.CLAUDE_PLUGIN_OPTION_MAX_EXPERIENCES_PER_PROJECT;
+    delete process.env.CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD;
+    delete process.env.CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_MAX;
   });
 
   it("overrides ollama_url from env", () => {
@@ -295,6 +297,40 @@ describe("applyPluginOptionOverrides", () => {
     const config = makeConfig();
     applyPluginOptionOverrides(config);
     expect(config.ollama_model).toBeUndefined();
+  });
+
+  it("overrides inject_corrective_bodies_score_threshold from env (#130)", () => {
+    process.env.CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD = "0.2";
+    const config = makeConfig();
+    applyPluginOptionOverrides(config);
+    expect(config.inject_corrective_bodies_score_threshold).toBe(0.2);
+  });
+
+  it("warns and ignores out-of-range threshold (#130)", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD = "10";
+    const config = makeConfig();
+    applyPluginOptionOverrides(config);
+    expect(config.inject_corrective_bodies_score_threshold).toBe(0.6);
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("invalid value"));
+    spy.mockRestore();
+  });
+
+  it("overrides inject_corrective_bodies_max from env (#130)", () => {
+    process.env.CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_MAX = "5";
+    const config = makeConfig();
+    applyPluginOptionOverrides(config);
+    expect(config.inject_corrective_bodies_max).toBe(5);
+  });
+
+  it("warns and ignores non-integer max bodies (#130)", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_MAX = "2.5";
+    const config = makeConfig();
+    applyPluginOptionOverrides(config);
+    expect(config.inject_corrective_bodies_max).toBe(3);
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("invalid value"));
+    spy.mockRestore();
   });
 
   it("does not override when env vars are not set", () => {

--- a/tests/hooks/common.test.ts
+++ b/tests/hooks/common.test.ts
@@ -306,6 +306,13 @@ describe("applyPluginOptionOverrides", () => {
     expect(config.inject_corrective_bodies_score_threshold).toBe(0.2);
   });
 
+  it("accepts threshold 0 (always inline) as a valid override (#130)", () => {
+    process.env.CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD = "0";
+    const config = makeConfig();
+    applyPluginOptionOverrides(config);
+    expect(config.inject_corrective_bodies_score_threshold).toBe(0);
+  });
+
   it("warns and ignores out-of-range threshold (#130)", () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     process.env.CLAUDE_PLUGIN_OPTION_INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD = "10";

--- a/tests/hooks/session-start.test.ts
+++ b/tests/hooks/session-start.test.ts
@@ -238,6 +238,16 @@ describe("session-start hook: retrieveAndInject", () => {
     });
     expect((injectionSignals[0].data as Record<string, unknown>).injected_ids).toHaveLength(1);
 
+    const rationale = (injectionSignals[0].data as Record<string, unknown>)
+      .entry_rationale as Array<{ id: string; score: number; bodies_inlined: boolean }>;
+    expect(rationale).toHaveLength(1);
+    expect(typeof rationale[0].id).toBe("string");
+    expect(typeof rationale[0].score).toBe("number");
+    expect(typeof rationale[0].bodies_inlined).toBe("boolean");
+    // score is rounded to 3 decimals
+    const decimals = rationale[0].score.toString().split(".")[1]?.length ?? 0;
+    expect(decimals).toBeLessThanOrEqual(3);
+
     ctx!.cleanup();
   });
 

--- a/tests/plugin-structure.test.ts
+++ b/tests/plugin-structure.test.ts
@@ -42,7 +42,14 @@ describe("plugin.json", () => {
     const userConfig = plugin.userConfig as Record<string, unknown>;
     expect(userConfig).toBeDefined();
 
-    const expectedKeys = ["ollama_url", "ollama_model", "verbosity", "max_experiences_per_project"];
+    const expectedKeys = [
+      "ollama_url",
+      "ollama_model",
+      "verbosity",
+      "max_experiences_per_project",
+      "inject_corrective_bodies_score_threshold",
+      "inject_corrective_bodies_max",
+    ];
     for (const key of expectedKeys) {
       expect(userConfig[key]).toBeDefined();
       const entry = userConfig[key] as Record<string, unknown>;

--- a/tests/retrieval/injector.test.ts
+++ b/tests/retrieval/injector.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatInjection } from "../../src/retrieval/injector.js";
+import { formatInjection, bodiesInlinedFor } from "../../src/retrieval/injector.js";
 import type { RetrievalResult } from "../../src/retrieval/types.js";
 import type { ExperienceEntry } from "../../src/store/types.js";
 
@@ -144,6 +144,68 @@ describe("formatInjection", () => {
     ]);
     const matches = result.match(/• "body-\d+"/g) ?? [];
     expect(matches.length).toBeLessThanOrEqual(3);
+  });
+
+  it("honors injected policy threshold override (#130)", () => {
+    const result = formatInjection(
+      [
+        makeResult({
+          type: "failure",
+          signal_type: "corrective_instruction",
+          signal_strength: 0.5,
+          corrective_bodies: ["low-score body"],
+          score: 0.3,
+        }),
+      ],
+      { correctiveBodiesScoreThreshold: 0.2, maxInlinedBodiesPerEntry: 3 }
+    );
+    expect(result).toContain('"low-score body"');
+  });
+
+  it("honors injected policy max override (#130)", () => {
+    const bodies = ["a", "b", "c", "d", "e"];
+    const result = formatInjection(
+      [
+        makeResult({
+          type: "failure",
+          signal_type: "corrective_instruction",
+          signal_strength: 0.9,
+          corrective_bodies: bodies,
+          score: 1.5,
+        }),
+      ],
+      { correctiveBodiesScoreThreshold: 0.6, maxInlinedBodiesPerEntry: 1 }
+    );
+    const matches = result.match(/•/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it("bodiesInlinedFor returns true only when threshold met and bodies exist (#130)", () => {
+    const failureWithBodies = makeResult({
+      type: "failure",
+      signal_type: "corrective_instruction",
+      corrective_bodies: ["x"],
+      score: 1.0,
+    });
+    const failureWithoutBodies = makeResult({
+      type: "failure",
+      signal_type: "corrective_instruction",
+      score: 1.0,
+    });
+    const successResult = makeResult({ score: 1.0 });
+    const policy = { correctiveBodiesScoreThreshold: 0.6, maxInlinedBodiesPerEntry: 3 };
+
+    expect(bodiesInlinedFor(failureWithBodies.entry, failureWithBodies.score, policy)).toBe(true);
+    expect(bodiesInlinedFor(failureWithoutBodies.entry, failureWithoutBodies.score, policy)).toBe(
+      false
+    );
+    expect(bodiesInlinedFor(successResult.entry, successResult.score, policy)).toBe(false);
+    expect(
+      bodiesInlinedFor(failureWithBodies.entry, failureWithBodies.score, {
+        ...policy,
+        correctiveBodiesScoreThreshold: 2.0,
+      })
+    ).toBe(false);
   });
 
   it("respects budget when entries have inlined corrective bodies (#128)", () => {


### PR DESCRIPTION
## Summary

Closes #130.

PR #132 (#128) で導入した `INJECT_CORRECTIVE_BODIES_SCORE_THRESHOLD` / `MAX_INLINED_BODIES_PER_ENTRY` の module-level 定数を **AcmConfig + plugin userConfig** 経由で上書き可能にする。注入理由の observability も session_signals に記録する。

- `AcmConfig`: `inject_corrective_bodies_score_threshold` (default 0.6) / `inject_corrective_bodies_max` (default 3)
- `CLAUDE_PLUGIN_OPTION_*` env override（range validation + warn-on-invalid）
- `plugin.json` userConfig に 2 項目追加
- `formatInjection(results, policy?)` に signature 変更（後方互換 default policy）
- `bodiesInlinedFor(entry, score, policy)` を helper として抽出（injector / session-start で共有）
- `session_signals.injection` data に `entry_rationale: [{id, score, bodies_inlined}]` を追加
- SPECIFICATION.md Section 3.1 更新（userConfig 参照、rationale log 明記）

## Test plan

- [x] 677 tests pass、tsc clean
- [x] threshold 0 が falsy 扱いされていた bug を pre-PR review で検出・修正

## Non-goals

- decision-point retrieve (#129)
- citation observability full (#125)
- source: user_invoked capture path tagging
- MCP tool 経由呼び出し元での config 反映（必要なら別 issue）

🤖 Generated with [Claude Code](https://claude.com/claude-code)