### PR TITLE
feat(acm): generate experience entries at PreCompact for long sessions

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -323,12 +323,21 @@ Past relevant experience:
 **Input**: `{ session_id, transcript_path, cwd, hook_event_name }`
 
 **Behavior**:
+
+**Phase 1 — Signal preservation (Issue #90)**:
 1. Skip if corrective signals already exist for this session (idempotent)
 2. Parse transcript and classify corrections (same logic as SessionEnd Phase 1)
 3. Store corrective signals with `source: "pre_compact"` marker
 4. Log preservation results
 
-**Rationale**: In long sessions, context compaction may truncate the transcript before SessionEnd runs. PreCompact ensures corrective signals are captured from the full transcript. SessionEnd then skips Phase 1 if PreCompact already preserved signals, and proceeds directly to Phase 2 (experience generation).
+**Phase 2 — Experience generation (Issue #134)**:
+5. Compute `lastEvaluatedAt` from `session_evaluations` (same segment boundary mechanism as SessionEnd, #115)
+6. Aggregate only signals recorded after `lastEvaluatedAt`
+7. Run `ExperienceGenerator` → `createWithEmbedding` (with Embedder fallback to embedding-less persist)
+8. Record evaluation in `session_evaluations` so subsequent SessionEnd / PreCompact invocations do not re-process the same signals
+9. Failure entries populate `corrective_bodies` (Section 3.6, #128)
+
+**Rationale**: In long-running sessions `/exit` rarely fires, so SessionEnd doesn't produce experience entries and retrieval starves. PreCompact is a natural mid-session boundary that already inspects the transcript; generating entries here surfaces corrective experience in `/acm:report` and subsequent session-start retrievals without waiting for a terminal event. The `session_evaluations` boundary ensures SessionEnd (when it eventually fires) only processes signals recorded *after* the last PreCompact evaluation, so entries are not duplicated.
 
 ### 3.8 Hook-Free Experience Generation (Experiment Runner)
 

--- a/src/hooks/pre-compact.ts
+++ b/src/hooks/pre-compact.ts
@@ -1,16 +1,217 @@
 /**
- * PreCompact hook — corrective signal preservation before compaction
- * Issue #90: feat: migrate to SessionEnd + PreCompact hook pair
+ * PreCompact hook — corrective signal preservation + experience entry generation
+ * Issue #90: feat: migrate to SessionEnd + PreCompact hook pair (Phase 1)
+ * Issue #134: feat: promote corrective signals to experience entries at PreCompact (Phase 2)
  *
- * Runs before context compaction to analyze the current transcript and
- * preserve corrective signals that would otherwise be lost when the
- * transcript is truncated. PreCompact cannot block compaction; it runs
- * before compaction begins. Best-effort preservation.
+ * Phase 1: analyze transcript to preserve corrective signals before compaction.
+ * Phase 2: generate experience entries from signals since the last segment boundary
+ *          so long-running sessions get surfaced in retrieval without waiting for SessionEnd.
+ *
+ * Phase 2 reuses the session_evaluations table (#115) so SessionEnd won't re-process
+ * the same signals. The Phase 2 logic intentionally mirrors session-end.ts; a future
+ * refactor may factor this out into a shared pipeline module.
  */
 
-import { bootstrapHook, requireInputString, runAsHookScript } from "./_common.js";
+import { bootstrapHook, requireInputString, runAsHookScript, type HookContext } from "./_common.js";
 import { parseTranscript } from "../signals/transcript-parser.js";
 import { classifyCorrections } from "../signals/corrective-classifier.js";
+import { ExperienceGenerator } from "../experience/generator.js";
+import { buildEmbeddingText } from "../retrieval/embedding-text.js";
+import type { Embedder as EmbedderType } from "../retrieval/embedder.js";
+
+async function runPhase1(ctx: HookContext, sessionId: string): Promise<void> {
+  const { input, config, signalStore } = ctx;
+
+  if (signalStore.hasSignalOfType(sessionId, "corrective_instruction")) {
+    ctx.logger.log("skip", "pre_compact_phase1_skipped", {
+      session_id: sessionId,
+      reason: "corrective_signals_already_exist",
+    });
+    return;
+  }
+
+  const transcriptPath = input.transcript_path;
+  if (typeof transcriptPath !== "string" || !transcriptPath) {
+    ctx.logger.log("skip", "pre_compact_phase1_skipped", {
+      session_id: sessionId,
+      reason: "no_transcript_path",
+    });
+    return;
+  }
+
+  const parsed = parseTranscript(transcriptPath);
+  if (parsed.turns.length <= 1) {
+    ctx.logger.log("skip", "pre_compact_phase1_skipped", {
+      session_id: sessionId,
+      reason: "single_turn_transcript",
+    });
+    return;
+  }
+
+  let corrections;
+  try {
+    corrections = await classifyCorrections(parsed, {
+      ollamaUrl: config.ollama_url,
+      model: config.ollama_model,
+    });
+  } catch (err) {
+    console.error(
+      `[ACM] pre-compact: transcript classification failed for "${transcriptPath}": ` +
+        `${err instanceof Error ? err.message : String(err)}`
+    );
+    ctx.logger.log("error", "pre_compact_classification_failed", {
+      session_id: sessionId,
+      transcript_path: transcriptPath,
+      error: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+    return;
+  }
+
+  const storedCorrections: typeof corrections = [];
+  for (const c of corrections) {
+    try {
+      signalStore.addSignal(sessionId, "corrective_instruction", {
+        prompt: c.message.text.slice(0, 200),
+        reason: c.reason,
+        confidence: c.confidence,
+        method: c.method,
+        source: "pre_compact",
+      });
+      storedCorrections.push(c);
+    } catch (storeErr) {
+      console.error(
+        `[ACM] pre-compact: failed to store corrective signal for session "${sessionId}": ` +
+          `${storeErr instanceof Error ? storeErr.message : String(storeErr)}`
+      );
+      ctx.logger.log("error", "pre_compact_signal_store_failed", {
+        session_id: sessionId,
+        error: storeErr instanceof Error ? storeErr.message : String(storeErr),
+      });
+    }
+  }
+
+  if (storedCorrections.length < corrections.length) {
+    console.error(
+      `[ACM] pre-compact: ${corrections.length - storedCorrections.length} of ${corrections.length} signal(s) failed to store for session "${sessionId}"`
+    );
+  }
+
+  if (storedCorrections.length > 0) {
+    ctx.logger.log("detection", "pre_compact_signals_preserved", {
+      session_id: sessionId,
+      corrective_count: storedCorrections.length,
+      methods: storedCorrections.map((c) => c.method),
+    });
+    console.error(
+      `[ACM] pre-compact: preserved ${storedCorrections.length} corrective signal(s) for session "${sessionId}"`
+    );
+  }
+}
+
+async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
+  const { config, signalStore, experienceStore, collector, projectName, logger } = ctx;
+
+  const lastEval = experienceStore.getLastEvaluatedAt(sessionId);
+  const summary = collector.getSessionSummary(
+    sessionId,
+    lastEval ? { after: lastEval } : undefined
+  );
+  const signals = signalStore.getBySession(sessionId, lastEval ?? undefined);
+
+  if (summary.total_signals === 0) {
+    logger.log("skip", "pre_compact_phase2_no_signals", {
+      session_id: sessionId,
+      last_evaluated_at: lastEval,
+    });
+    return;
+  }
+
+  const generator = new ExperienceGenerator({
+    capture_turns: config.capture_turns,
+    promotion_threshold: config.promotion_threshold,
+  });
+  const entries = generator.generate({ session_id: sessionId, summary, signals });
+
+  if (entries.length === 0) {
+    experienceStore.recordEvaluation(sessionId, 0);
+    logger.log("skip", "pre_compact_phase2_no_entries", {
+      session_id: sessionId,
+      last_evaluated_at: lastEval,
+    });
+    return;
+  }
+
+  let embedder: EmbedderType | undefined;
+  let embedderReady = false;
+  try {
+    const { Embedder } = await import("../retrieval/embedder.js");
+    embedder = new Embedder();
+    await embedder.initialize();
+    embedderReady = true;
+  } catch (err) {
+    console.error(
+      `[ACM] pre-compact: Embedder initialization failed, storing entries without embedding: ` +
+        `${err instanceof Error ? err.message : String(err)}`
+    );
+    logger.log("error", "pre_compact_embedder_init_failed", {
+      session_id: sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  let persisted = 0;
+  try {
+    for (const entryData of entries) {
+      try {
+        let saved;
+        if (embedderReady && embedder) {
+          const text = buildEmbeddingText(entryData);
+          const embedding = await embedder.embed(text);
+          saved = experienceStore.createWithEmbedding(
+            { ...entryData, project: projectName },
+            embedding
+          );
+        } else {
+          saved = experienceStore.create({ ...entryData, project: projectName });
+        }
+        if (saved) persisted++;
+      } catch (entryErr) {
+        console.error(
+          `[ACM] pre-compact: failed to persist entry (type="${entryData.type}") ` +
+            `for session "${sessionId}": ` +
+            `${entryErr instanceof Error ? entryErr.message : String(entryErr)}`
+        );
+        logger.log("error", "pre_compact_entry_persist_failed", {
+          session_id: sessionId,
+          entry_type: entryData.type,
+          error: entryErr instanceof Error ? entryErr.message : String(entryErr),
+        });
+      }
+    }
+  } finally {
+    if (embedder) embedder.dispose();
+  }
+
+  // If all entries failed to persist, don't advance the segment boundary so
+  // signals remain eligible for the next SessionEnd / PreCompact attempt.
+  if (persisted === 0 && entries.length > 0) {
+    logger.log("error", "pre_compact_all_entries_failed_no_boundary_advance", {
+      session_id: sessionId,
+      entries_attempted: entries.length,
+    });
+    return;
+  }
+
+  experienceStore.recordEvaluation(sessionId, persisted);
+  logger.log("generation", "pre_compact_experiences_created", {
+    session_id: sessionId,
+    generated: entries.length,
+    persisted,
+    types: entries.map((e) => e.type),
+    embedded: embedderReady,
+  });
+}
 
 export async function handlePreCompact(stdin: string): Promise<void> {
   const ctx = await bootstrapHook(stdin);
@@ -18,95 +219,9 @@ export async function handlePreCompact(stdin: string): Promise<void> {
 
   let sessionId: string | undefined;
   try {
-    const { input, config, signalStore } = ctx;
-    sessionId = requireInputString(input, "session_id", "PreCompact");
-
-    // Skip if corrective signals already exist for this session
-    if (signalStore.hasSignalOfType(sessionId, "corrective_instruction")) {
-      ctx.logger.log("skip", "pre_compact_skipped", {
-        session_id: sessionId,
-        reason: "corrective_signals_already_exist",
-      });
-      return;
-    }
-
-    const transcriptPath = input.transcript_path;
-    if (typeof transcriptPath !== "string" || !transcriptPath) {
-      ctx.logger.log("skip", "pre_compact_skipped", {
-        session_id: sessionId,
-        reason: "no_transcript_path",
-      });
-      return;
-    }
-
-    const parsed = parseTranscript(transcriptPath);
-    if (parsed.turns.length <= 1) {
-      ctx.logger.log("skip", "pre_compact_skipped", {
-        session_id: sessionId,
-        reason: "single_turn_transcript",
-      });
-      return;
-    }
-
-    let corrections;
-    try {
-      corrections = await classifyCorrections(parsed, {
-        ollamaUrl: config.ollama_url,
-        model: config.ollama_model,
-      });
-    } catch (err) {
-      console.error(
-        `[ACM] pre-compact: transcript classification failed for "${transcriptPath}": ` +
-          `${err instanceof Error ? err.message : String(err)}`
-      );
-      ctx.logger.log("error", "pre_compact_classification_failed", {
-        session_id: sessionId,
-        transcript_path: transcriptPath,
-        error: err instanceof Error ? err.message : String(err),
-        stack: err instanceof Error ? err.stack : undefined,
-      });
-      return;
-    }
-
-    const storedCorrections: typeof corrections = [];
-    for (const c of corrections) {
-      try {
-        signalStore.addSignal(sessionId, "corrective_instruction", {
-          prompt: c.message.text.slice(0, 200),
-          reason: c.reason,
-          confidence: c.confidence,
-          method: c.method,
-          source: "pre_compact",
-        });
-        storedCorrections.push(c);
-      } catch (storeErr) {
-        console.error(
-          `[ACM] pre-compact: failed to store corrective signal for session "${sessionId}": ` +
-            `${storeErr instanceof Error ? storeErr.message : String(storeErr)}`
-        );
-        ctx.logger.log("error", "pre_compact_signal_store_failed", {
-          session_id: sessionId,
-          error: storeErr instanceof Error ? storeErr.message : String(storeErr),
-        });
-      }
-    }
-
-    if (storedCorrections.length < corrections.length) {
-      console.error(
-        `[ACM] pre-compact: ${corrections.length - storedCorrections.length} of ${corrections.length} signal(s) failed to store for session "${sessionId}"`
-      );
-    }
-
-    if (storedCorrections.length > 0) {
-      ctx.logger.log("detection", "pre_compact_signals_preserved", {
-        session_id: sessionId,
-        corrective_count: storedCorrections.length,
-        methods: storedCorrections.map((c) => c.method),
-      });
-      console.error(
-        `[ACM] pre-compact: preserved ${storedCorrections.length} corrective signal(s) for session "${sessionId}"`
-      );
-    }
+    sessionId = requireInputString(ctx.input, "session_id", "PreCompact");
+    await runPhase1(ctx, sessionId);
+    await runPhase2(ctx, sessionId);
   } finally {
     try {
       ctx.cleanup();

--- a/src/hooks/pre-compact.ts
+++ b/src/hooks/pre-compact.ts
@@ -22,7 +22,20 @@ import type { Embedder as EmbedderType } from "../retrieval/embedder.js";
 async function runPhase1(ctx: HookContext, sessionId: string): Promise<void> {
   const { input, config, signalStore } = ctx;
 
-  if (signalStore.hasSignalOfType(sessionId, "corrective_instruction")) {
+  // DB / FS reads are wrapped so a storage or file-format error in Phase 1
+  // doesn't crash the hook before Phase 2 can run on prior signals.
+  let alreadyHasSignals: boolean;
+  try {
+    alreadyHasSignals = signalStore.hasSignalOfType(sessionId, "corrective_instruction");
+  } catch (err) {
+    ctx.logger.log("error", "pre_compact_signal_check_failed", {
+      session_id: sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  if (alreadyHasSignals) {
     ctx.logger.log("skip", "pre_compact_phase1_skipped", {
       session_id: sessionId,
       reason: "corrective_signals_already_exist",
@@ -39,7 +52,22 @@ async function runPhase1(ctx: HookContext, sessionId: string): Promise<void> {
     return;
   }
 
-  const parsed = parseTranscript(transcriptPath);
+  let parsed;
+  try {
+    parsed = parseTranscript(transcriptPath);
+  } catch (err) {
+    console.error(
+      `[ACM] pre-compact: parseTranscript failed for "${transcriptPath}": ` +
+        `${err instanceof Error ? err.message : String(err)}`
+    );
+    ctx.logger.log("error", "pre_compact_transcript_parse_failed", {
+      session_id: sessionId,
+      transcript_path: transcriptPath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
   if (parsed.turns.length <= 1) {
     ctx.logger.log("skip", "pre_compact_phase1_skipped", {
       session_id: sessionId,

--- a/src/hooks/pre-compact.ts
+++ b/src/hooks/pre-compact.ts
@@ -193,8 +193,17 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
     if (embedder) embedder.dispose();
   }
 
-  // If all entries failed to persist, don't advance the segment boundary so
-  // signals remain eligible for the next SessionEnd / PreCompact attempt.
+  if (persisted < entries.length) {
+    console.error(
+      `[ACM] pre-compact: ${entries.length - persisted} of ${entries.length} ` +
+        `experience entries failed to persist for session "${sessionId}"`
+    );
+  }
+
+  // Leaving the segment boundary un-advanced lets the next SessionEnd / PreCompact
+  // invocation re-process the same signals (idempotent recovery). This only applies
+  // when EVERY entry failed; partial success still advances, so individual failed
+  // entries are dropped rather than duplicated on retry.
   if (persisted === 0 && entries.length > 0) {
     logger.log("error", "pre_compact_all_entries_failed_no_boundary_advance", {
       session_id: sessionId,

--- a/tests/hooks/pre-compact.test.ts
+++ b/tests/hooks/pre-compact.test.ts
@@ -215,7 +215,119 @@ describe("PreCompact hook", () => {
         // Second call finds no new signals (Phase 1 skip) and no new signals after
         // last_evaluated_at (Phase 2 skip), so no extra entry is created.
         const failures = entries.filter((e) => e.type === "failure");
-        expect(failures.length).toBeLessThanOrEqual(1);
+        expect(failures.length).toBe(1);
+      } finally {
+        db.close();
+      }
+    }
+  );
+
+  it(
+    "Phase 2 runs independently when Phase 1 is skipped due to pre-existing signals (#134)",
+    { timeout: 15000 },
+    async () => {
+      const dbPath = setupEnv(TMP_DIR);
+      // Pre-seed corrective signals so Phase 1 will skip
+      const db0 = await initializeDatabase(dbPath);
+      try {
+        const store = new SessionSignalStore(db0);
+        for (let i = 0; i < 3; i++) {
+          store.addSignal("pre-compact-phase2-only", "corrective_instruction", {
+            prompt: `preseeded corrective ${i}`,
+            reason: "test",
+            confidence: 0.9,
+            method: "llm",
+            source: "pre_compact",
+          });
+        }
+      } finally {
+        db0.close();
+      }
+
+      const transcriptPath = writeTranscript(TMP_DIR, [
+        userLine("Stub"),
+        assistantLine("ok"),
+        userLine("Stop"),
+      ]);
+      const stdin = JSON.stringify({
+        session_id: "pre-compact-phase2-only",
+        transcript_path: transcriptPath,
+        cwd: TMP_DIR,
+      });
+
+      await handlePreCompact(stdin);
+
+      const db = await initializeDatabase(dbPath);
+      try {
+        const expStore = new ExperienceStore(db, DEFAULT_CONFIG);
+        const entries = expStore.list().filter((e) => e.session_id === "pre-compact-phase2-only");
+        const failure = entries.find((e) => e.type === "failure");
+        expect(failure).toBeDefined();
+        expect(failure!.corrective_bodies?.length ?? 0).toBeGreaterThan(0);
+        expect(expStore.getLastEvaluatedAt("pre-compact-phase2-only")).toBeTruthy();
+      } finally {
+        db.close();
+      }
+    }
+  );
+
+  it(
+    "does not advance boundary when every entry fails to persist (#134)",
+    { timeout: 15000 },
+    async () => {
+      const dbPath = setupEnv(TMP_DIR);
+      // Pre-seed signals
+      const db0 = await initializeDatabase(dbPath);
+      try {
+        const store = new SessionSignalStore(db0);
+        for (let i = 0; i < 3; i++) {
+          store.addSignal("pre-compact-persist-fail", "corrective_instruction", {
+            prompt: `fail-test corrective ${i}`,
+            reason: "test",
+            confidence: 0.9,
+            method: "llm",
+            source: "pre_compact",
+          });
+        }
+      } finally {
+        db0.close();
+      }
+
+      // Make every insertEntry throw by mocking createWithEmbedding + create
+      const storeMod = await import("../../src/store/experience-store.js");
+      const createSpy = vi
+        .spyOn(storeMod.ExperienceStore.prototype, "createWithEmbedding")
+        .mockImplementation(() => {
+          throw new Error("simulated persist failure");
+        });
+      const createPlainSpy = vi
+        .spyOn(storeMod.ExperienceStore.prototype, "create")
+        .mockImplementation(() => {
+          throw new Error("simulated persist failure");
+        });
+
+      const transcriptPath = writeTranscript(TMP_DIR, [
+        userLine("Stub"),
+        assistantLine("ok"),
+        userLine("Stop"),
+      ]);
+      const stdin = JSON.stringify({
+        session_id: "pre-compact-persist-fail",
+        transcript_path: transcriptPath,
+        cwd: TMP_DIR,
+      });
+
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      await handlePreCompact(stdin);
+      errSpy.mockRestore();
+      createSpy.mockRestore();
+      createPlainSpy.mockRestore();
+
+      const db = await initializeDatabase(dbPath);
+      try {
+        const expStore = new ExperienceStore(db, DEFAULT_CONFIG);
+        // Boundary was NOT advanced — signals stay eligible for retry
+        expect(expStore.getLastEvaluatedAt("pre-compact-persist-fail")).toBeNull();
       } finally {
         db.close();
       }

--- a/tests/hooks/pre-compact.test.ts
+++ b/tests/hooks/pre-compact.test.ts
@@ -6,6 +6,8 @@ import { mkdirSync, rmSync } from "node:fs";
 import { handlePreCompact } from "../../src/hooks/pre-compact.js";
 import { initializeDatabase } from "../../src/store/schema.js";
 import { SessionSignalStore } from "../../src/signals/session-store.js";
+import { ExperienceStore } from "../../src/store/experience-store.js";
+import { DEFAULT_CONFIG } from "../../src/store/types.js";
 import {
   userLine,
   interruptLine,
@@ -137,6 +139,88 @@ describe("PreCompact hook", () => {
       db.close();
     }
   });
+
+  it(
+    "generates experience entry with corrective_bodies at PreCompact (#134)",
+    { timeout: 20000 },
+    async () => {
+      const dbPath = setupEnv(TMP_DIR);
+      const transcriptPath = writeTranscript(TMP_DIR, [
+        userLine("Implement feature X"),
+        assistantLine("Working on it..."),
+        interruptLine(),
+        userLine("No, that's wrong. Use a different approach please"),
+        assistantLine("OK, using a different approach"),
+        userLine("Still wrong. Use TypeScript generics for the signature."),
+        assistantLine("Understood, applying generics."),
+        userLine("Actually, rewrite the whole function from scratch."),
+        assistantLine("Rewriting."),
+      ]);
+
+      const stdin = JSON.stringify({
+        session_id: "pre-compact-entry-s1",
+        transcript_path: transcriptPath,
+        cwd: TMP_DIR,
+      });
+
+      await handlePreCompact(stdin);
+
+      const db = await initializeDatabase(dbPath);
+      try {
+        const expStore = new ExperienceStore(db, DEFAULT_CONFIG);
+        const entries = expStore.list().filter((e) => e.session_id === "pre-compact-entry-s1");
+        expect(entries.length).toBeGreaterThan(0);
+        const failure = entries.find((e) => e.type === "failure");
+        expect(failure).toBeDefined();
+        expect(failure!.corrective_bodies).toBeDefined();
+        expect(failure!.corrective_bodies!.length).toBeGreaterThan(0);
+
+        // session_evaluations marker was recorded so SessionEnd won't re-process
+        const lastEval = expStore.getLastEvaluatedAt("pre-compact-entry-s1");
+        expect(lastEval).toBeTruthy();
+      } finally {
+        db.close();
+      }
+    }
+  );
+
+  it(
+    "advances segment boundary so subsequent PreCompact does not duplicate entries (#134)",
+    { timeout: 20000 },
+    async () => {
+      const dbPath = setupEnv(TMP_DIR);
+      const transcriptPath = writeTranscript(TMP_DIR, [
+        userLine("Do X"),
+        assistantLine("ok"),
+        interruptLine(),
+        userLine("No that's wrong, do Y instead"),
+        assistantLine("ok Y"),
+        userLine("Still wrong, do Z"),
+        assistantLine("ok Z"),
+      ]);
+
+      const stdin = JSON.stringify({
+        session_id: "pre-compact-entry-s2",
+        transcript_path: transcriptPath,
+        cwd: TMP_DIR,
+      });
+
+      await handlePreCompact(stdin);
+      await handlePreCompact(stdin);
+
+      const db = await initializeDatabase(dbPath);
+      try {
+        const expStore = new ExperienceStore(db, DEFAULT_CONFIG);
+        const entries = expStore.list().filter((e) => e.session_id === "pre-compact-entry-s2");
+        // Second call finds no new signals (Phase 1 skip) and no new signals after
+        // last_evaluated_at (Phase 2 skip), so no extra entry is created.
+        const failures = entries.filter((e) => e.type === "failure");
+        expect(failures.length).toBeLessThanOrEqual(1);
+      } finally {
+        db.close();
+      }
+    }
+  );
 
   it("continues gracefully when transcript analysis fails", async () => {
     setupEnv(TMP_DIR);


### PR DESCRIPTION
## Summary

Closes #134. Follow-up race: #135.

長セッションで SessionEnd が発火しない状態が続くと、PreCompact で救出された corrective signal (#119) が entry 化されず、#128 (corrective_bodies) の効果が DB に現れなかった。実測で 2 日間・24 件の corrective が stall。本 PR で PreCompact に **Phase 2 (experience generation)** を追加し、`session_evaluations` segment boundary (#115) を流用して SessionEnd と重複しない形で entry を生成する。

- `src/hooks/pre-compact.ts`: `runPhase1` / `runPhase2` に分離、Phase 1 skip は Phase 2 を短絡しない
- Phase 2 は session-end.ts の Phase 2 と同パターン（ExperienceGenerator → createWithEmbedding / fallback → recordEvaluation）
- 失敗 entry に `corrective_bodies` が populate される
- `docs/SPECIFICATION.md` Section 3.7 を Phase 1/2 構成で更新

## Test plan

- [x] 680 tests pass、tsc clean
- [x] `pre-compact.test.ts` に (a) entry 生成 + corrective_bodies populated、(b) 二重実行で duplicate 発生しない、を追加
- [ ] 実機: `sqlite3 ~/.acm/experiences.db` で compact 後に新 failure entry が `corrective_bodies IS NOT NULL` で現れることを確認
- [ ] 実機: `/acm:report` に新 entry が surface することを確認

## Follow-up

- #135: `getLastEvaluatedAt` + `recordEvaluation` のアトミック化（PreCompact と SessionEnd の race 緩和）

🤖 Generated with [Claude Code](https://claude.com/claude-code)