### PR TITLE
feat(acm): generate experience entries at PreCompact for long sessions

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -323,12 +323,21 @@ Past relevant experience:
 **Input**: `{ session_id, transcript_path, cwd, hook_event_name }`
 
 **Behavior**:
+
+**Phase 1 — Signal preservation (Issue #90)**:
 1. Skip if corrective signals already exist for this session (idempotent)
 2. Parse transcript and classify corrections (same logic as SessionEnd Phase 1)
 3. Store corrective signals with `source: "pre_compact"` marker
 4. Log preservation results
 
-**Rationale**: In long sessions, context compaction may truncate the transcript before SessionEnd runs. PreCompact ensures corrective signals are captured from the full transcript. SessionEnd then skips Phase 1 if PreCompact already preserved signals, and proceeds directly to Phase 2 (experience generation).
+**Phase 2 — Experience generation (Issue #134)**:
+5. Compute `lastEvaluatedAt` from `session_evaluations` (same segment boundary mechanism as SessionEnd, #115)
+6. Aggregate only signals recorded after `lastEvaluatedAt`
+7. Run `ExperienceGenerator` → `createWithEmbedding` (with Embedder fallback to embedding-less persist)
+8. Record evaluation in `session_evaluations` so subsequent SessionEnd / PreCompact invocations do not re-process the same signals
+9. Failure entries populate `corrective_bodies` (Section 3.6, #128)
+
+**Rationale**: In long-running sessions `/exit` rarely fires, so SessionEnd doesn't produce experience entries and retrieval starves. PreCompact is a natural mid-session boundary that already inspects the transcript; generating entries here surfaces corrective experience in `/acm:report` and subsequent session-start retrievals without waiting for a terminal event. The `session_evaluations` boundary ensures SessionEnd (when it eventually fires) only processes signals recorded *after* the last PreCompact evaluation, so entries are not duplicated.
 
 ### 3.8 Hook-Free Experience Generation (Experiment Runner)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,8 @@ const KNOWN_CONFIG_KEYS = new Set<string>([
   "ollama_model",
   "max_experiences_per_project",
   "recency_half_life_days",
+  "inject_corrective_bodies_score_threshold",
+  "inject_corrective_bodies_max",
 ]);
 
 export function expandTilde(filePath: string): string {

--- a/src/hooks/pre-compact.ts
+++ b/src/hooks/pre-compact.ts
@@ -140,11 +140,25 @@ async function runPhase1(ctx: HookContext, sessionId: string): Promise<void> {
 async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
   const { config, signalStore, experienceStore, collector, projectName, logger } = ctx;
 
-  const lastEval = experienceStore.getLastEvaluatedAt(sessionId);
-  const summary = collector.getSessionSummary(
-    sessionId,
-    lastEval ? { after: lastEval } : undefined
-  );
+  // Phase 2 store reads: DB failures should log and return, not crash the hook.
+  let lastEval: string | null;
+  let summary: ReturnType<typeof collector.getSessionSummary>;
+  let signals: ReturnType<typeof signalStore.getBySession>;
+  try {
+    lastEval = experienceStore.getLastEvaluatedAt(sessionId);
+    summary = collector.getSessionSummary(sessionId, lastEval ? { after: lastEval } : undefined);
+  } catch (err) {
+    console.error(
+      `[ACM] pre-compact: Phase 2 store read (summary) failed for session "${sessionId}": ` +
+        `${err instanceof Error ? err.message : String(err)}`
+    );
+    logger.log("error", "pre_compact_phase2_store_read_failed", {
+      session_id: sessionId,
+      stage: "summary",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
 
   if (summary.total_signals === 0) {
     logger.log("skip", "pre_compact_phase2_no_signals", {
@@ -154,7 +168,20 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
     return;
   }
 
-  const signals = signalStore.getBySession(sessionId, lastEval ?? undefined);
+  try {
+    signals = signalStore.getBySession(sessionId, lastEval ?? undefined);
+  } catch (err) {
+    console.error(
+      `[ACM] pre-compact: Phase 2 store read (signals) failed for session "${sessionId}": ` +
+        `${err instanceof Error ? err.message : String(err)}`
+    );
+    logger.log("error", "pre_compact_phase2_store_read_failed", {
+      session_id: sessionId,
+      stage: "signals",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
 
   const generator = new ExperienceGenerator({
     capture_turns: config.capture_turns,
@@ -163,7 +190,19 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
   const entries = generator.generate({ session_id: sessionId, summary, signals });
 
   if (entries.length === 0) {
-    experienceStore.recordEvaluation(sessionId, 0);
+    try {
+      experienceStore.recordEvaluation(sessionId, 0);
+    } catch (err) {
+      console.error(
+        `[ACM] pre-compact: recordEvaluation(0) failed for session "${sessionId}": ` +
+          `${err instanceof Error ? err.message : String(err)}`
+      );
+      logger.log("error", "pre_compact_record_evaluation_failed", {
+        session_id: sessionId,
+        persisted: 0,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
     logger.log("skip", "pre_compact_phase2_no_entries", {
       session_id: sessionId,
       last_evaluated_at: lastEval,
@@ -193,11 +232,22 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
   let embeddedCount = 0;
   try {
     for (const entryData of entries) {
+      let embedFailed = false;
+      let embedErr: unknown = null;
+      let embedding: Float32Array | null = null;
+      if (embedderReady && embedder) {
+        try {
+          const text = buildEmbeddingText(entryData);
+          embedding = await embedder.embed(text);
+        } catch (e) {
+          embedFailed = true;
+          embedErr = e;
+        }
+      }
+
       try {
         let saved;
-        if (embedderReady && embedder) {
-          const text = buildEmbeddingText(entryData);
-          const embedding = await embedder.embed(text);
+        if (embedding) {
           saved = experienceStore.createWithEmbedding(
             { ...entryData, project: projectName },
             embedding
@@ -207,35 +257,23 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
           saved = experienceStore.create({ ...entryData, project: projectName });
         }
         if (saved) persisted++;
+        if (embedFailed) {
+          // embed() threw but DB persist (fallback) succeeded; treat as embedding-less fallback
+          if (embedderReady) embedderReady = false;
+          logger.log("generation", "pre_compact_entry_embedding_less_retry", {
+            session_id: sessionId,
+            entry_type: entryData.type,
+            initial_error: embedErr instanceof Error ? embedErr.message : String(embedErr),
+          });
+        }
       } catch (entryErr) {
-        // On embed failure: disable embedder for subsequent entries AND retry
-        // this entry with embedding-less persist so it isn't silently dropped.
-        if (embedderReady) {
+        // Sub-cases:
+        //   (a) embed succeeded, createWithEmbedding failed — DB issue, not embed.
+        //       Do NOT disable embedder; retry would hit the same DB error.
+        //   (b) embed failed, fallback create() also failed — both paths broken.
+        //       Disable embedder for remaining entries; no more retries for this one.
+        if (embedFailed && embedderReady) {
           embedderReady = false;
-          try {
-            const retrySaved = experienceStore.create({ ...entryData, project: projectName });
-            if (retrySaved) {
-              persisted++;
-              logger.log("generation", "pre_compact_entry_embedding_less_retry", {
-                session_id: sessionId,
-                entry_type: entryData.type,
-                initial_error: entryErr instanceof Error ? entryErr.message : String(entryErr),
-              });
-              continue;
-            }
-          } catch (retryErr) {
-            console.error(
-              `[ACM] pre-compact: embedding-less retry also failed for entry (type="${entryData.type}") ` +
-                `in session "${sessionId}": ` +
-                `${retryErr instanceof Error ? retryErr.message : String(retryErr)}`
-            );
-            logger.log("error", "pre_compact_entry_retry_failed", {
-              session_id: sessionId,
-              entry_type: entryData.type,
-              initial_error: entryErr instanceof Error ? entryErr.message : String(entryErr),
-              retry_error: retryErr instanceof Error ? retryErr.message : String(retryErr),
-            });
-          }
         }
         console.error(
           `[ACM] pre-compact: failed to persist entry (type="${entryData.type}") ` +

--- a/src/hooks/pre-compact.ts
+++ b/src/hooks/pre-compact.ts
@@ -145,7 +145,6 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
     sessionId,
     lastEval ? { after: lastEval } : undefined
   );
-  const signals = signalStore.getBySession(sessionId, lastEval ?? undefined);
 
   if (summary.total_signals === 0) {
     logger.log("skip", "pre_compact_phase2_no_signals", {
@@ -154,6 +153,8 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
     });
     return;
   }
+
+  const signals = signalStore.getBySession(sessionId, lastEval ?? undefined);
 
   const generator = new ExperienceGenerator({
     capture_turns: config.capture_turns,
@@ -205,6 +206,10 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
         }
         if (saved) persisted++;
       } catch (entryErr) {
+        // Persistent embed failure (not just this entry) collapses the rest of
+        // the loop into embedding-less persist so we don't lose all remaining
+        // entries to the same broken model.
+        if (embedderReady) embedderReady = false;
         console.error(
           `[ACM] pre-compact: failed to persist entry (type="${entryData.type}") ` +
             `for session "${sessionId}": ` +

--- a/src/hooks/pre-compact.ts
+++ b/src/hooks/pre-compact.ts
@@ -190,6 +190,7 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
   }
 
   let persisted = 0;
+  let embeddedCount = 0;
   try {
     for (const entryData of entries) {
       try {
@@ -201,6 +202,7 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
             { ...entryData, project: projectName },
             embedding
           );
+          if (saved) embeddedCount++;
         } else {
           saved = experienceStore.create({ ...entryData, project: projectName });
         }
@@ -214,7 +216,7 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
             const retrySaved = experienceStore.create({ ...entryData, project: projectName });
             if (retrySaved) {
               persisted++;
-              logger.log("skip", "pre_compact_entry_embedding_less_retry", {
+              logger.log("generation", "pre_compact_entry_embedding_less_retry", {
                 session_id: sessionId,
                 entry_type: entryData.type,
                 initial_error: entryErr instanceof Error ? entryErr.message : String(entryErr),
@@ -227,6 +229,12 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
                 `in session "${sessionId}": ` +
                 `${retryErr instanceof Error ? retryErr.message : String(retryErr)}`
             );
+            logger.log("error", "pre_compact_entry_retry_failed", {
+              session_id: sessionId,
+              entry_type: entryData.type,
+              initial_error: entryErr instanceof Error ? entryErr.message : String(entryErr),
+              retry_error: retryErr instanceof Error ? retryErr.message : String(retryErr),
+            });
           }
         }
         console.error(
@@ -264,9 +272,11 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
     return;
   }
 
+  let boundaryAdvanced = true;
   try {
     experienceStore.recordEvaluation(sessionId, persisted);
   } catch (err) {
+    boundaryAdvanced = false;
     console.error(
       `[ACM] pre-compact: boundary advance failed for session "${sessionId}", ` +
         `${persisted} entries may duplicate on next invocation: ` +
@@ -282,8 +292,9 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
     session_id: sessionId,
     generated: entries.length,
     persisted,
+    embedded_count: embeddedCount,
     types: entries.map((e) => e.type),
-    embedded: embedderReady,
+    boundary_advanced: boundaryAdvanced,
   });
 }
 

--- a/src/hooks/pre-compact.ts
+++ b/src/hooks/pre-compact.ts
@@ -1,16 +1,254 @@
 /**
- * PreCompact hook — corrective signal preservation before compaction
- * Issue #90: feat: migrate to SessionEnd + PreCompact hook pair
+ * PreCompact hook — corrective signal preservation + experience entry generation
+ * Issue #90: feat: migrate to SessionEnd + PreCompact hook pair (Phase 1)
+ * Issue #134: feat: promote corrective signals to experience entries at PreCompact (Phase 2)
  *
- * Runs before context compaction to analyze the current transcript and
- * preserve corrective signals that would otherwise be lost when the
- * transcript is truncated. PreCompact cannot block compaction; it runs
- * before compaction begins. Best-effort preservation.
+ * Phase 1: analyze transcript to preserve corrective signals before compaction.
+ * Phase 2: generate experience entries from signals since the last segment boundary
+ *          so long-running sessions get surfaced in retrieval without waiting for SessionEnd.
+ *
+ * Phase 2 reuses the session_evaluations table (#115) so SessionEnd won't re-process
+ * the same signals. Phase 2 logic intentionally mirrors session-end.ts; a future
+ * refactor may factor this out into a shared pipeline module.
  */
 
-import { bootstrapHook, requireInputString, runAsHookScript } from "./_common.js";
+import { bootstrapHook, requireInputString, runAsHookScript, type HookContext } from "./_common.js";
 import { parseTranscript } from "../signals/transcript-parser.js";
 import { classifyCorrections } from "../signals/corrective-classifier.js";
+import { ExperienceGenerator } from "../experience/generator.js";
+import { buildEmbeddingText } from "../retrieval/embedding-text.js";
+import type { Embedder as EmbedderType } from "../retrieval/embedder.js";
+
+async function runPhase1(ctx: HookContext, sessionId: string): Promise<void> {
+  const { input, config, signalStore } = ctx;
+
+  // DB / FS reads are wrapped so storage or file-format errors in Phase 1
+  // don't crash the hook before Phase 2 can run on prior signals.
+  let alreadyHasSignals: boolean;
+  try {
+    alreadyHasSignals = signalStore.hasSignalOfType(sessionId, "corrective_instruction");
+  } catch (err) {
+    ctx.logger.log("error", "pre_compact_signal_check_failed", {
+      session_id: sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  if (alreadyHasSignals) {
+    ctx.logger.log("skip", "pre_compact_phase1_skipped", {
+      session_id: sessionId,
+      reason: "corrective_signals_already_exist",
+    });
+    return;
+  }
+
+  const transcriptPath = input.transcript_path;
+  if (typeof transcriptPath !== "string" || !transcriptPath) {
+    ctx.logger.log("skip", "pre_compact_phase1_skipped", {
+      session_id: sessionId,
+      reason: "no_transcript_path",
+    });
+    return;
+  }
+
+  let parsed;
+  try {
+    parsed = parseTranscript(transcriptPath);
+  } catch (err) {
+    console.error(
+      `[ACM] pre-compact: parseTranscript failed for "${transcriptPath}": ` +
+        `${err instanceof Error ? err.message : String(err)}`
+    );
+    ctx.logger.log("error", "pre_compact_transcript_parse_failed", {
+      session_id: sessionId,
+      transcript_path: transcriptPath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  if (parsed.turns.length <= 1) {
+    ctx.logger.log("skip", "pre_compact_phase1_skipped", {
+      session_id: sessionId,
+      reason: "single_turn_transcript",
+    });
+    return;
+  }
+
+  let corrections;
+  try {
+    corrections = await classifyCorrections(parsed, {
+      ollamaUrl: config.ollama_url,
+      model: config.ollama_model,
+    });
+  } catch (err) {
+    console.error(
+      `[ACM] pre-compact: transcript classification failed for "${transcriptPath}": ` +
+        `${err instanceof Error ? err.message : String(err)}`
+    );
+    ctx.logger.log("error", "pre_compact_classification_failed", {
+      session_id: sessionId,
+      transcript_path: transcriptPath,
+      error: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+    return;
+  }
+
+  const storedCorrections: typeof corrections = [];
+  for (const c of corrections) {
+    try {
+      signalStore.addSignal(sessionId, "corrective_instruction", {
+        prompt: c.message.text.slice(0, 200),
+        reason: c.reason,
+        confidence: c.confidence,
+        method: c.method,
+        source: "pre_compact",
+      });
+      storedCorrections.push(c);
+    } catch (storeErr) {
+      console.error(
+        `[ACM] pre-compact: failed to store corrective signal for session "${sessionId}": ` +
+          `${storeErr instanceof Error ? storeErr.message : String(storeErr)}`
+      );
+      ctx.logger.log("error", "pre_compact_signal_store_failed", {
+        session_id: sessionId,
+        error: storeErr instanceof Error ? storeErr.message : String(storeErr),
+      });
+    }
+  }
+
+  if (storedCorrections.length < corrections.length) {
+    console.error(
+      `[ACM] pre-compact: ${corrections.length - storedCorrections.length} of ${corrections.length} signal(s) failed to store for session "${sessionId}"`
+    );
+  }
+
+  if (storedCorrections.length > 0) {
+    ctx.logger.log("detection", "pre_compact_signals_preserved", {
+      session_id: sessionId,
+      corrective_count: storedCorrections.length,
+      methods: storedCorrections.map((c) => c.method),
+    });
+    console.error(
+      `[ACM] pre-compact: preserved ${storedCorrections.length} corrective signal(s) for session "${sessionId}"`
+    );
+  }
+}
+
+async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
+  const { config, signalStore, experienceStore, collector, projectName, logger } = ctx;
+
+  const lastEval = experienceStore.getLastEvaluatedAt(sessionId);
+  const summary = collector.getSessionSummary(
+    sessionId,
+    lastEval ? { after: lastEval } : undefined
+  );
+  const signals = signalStore.getBySession(sessionId, lastEval ?? undefined);
+
+  if (summary.total_signals === 0) {
+    logger.log("skip", "pre_compact_phase2_no_signals", {
+      session_id: sessionId,
+      last_evaluated_at: lastEval,
+    });
+    return;
+  }
+
+  const generator = new ExperienceGenerator({
+    capture_turns: config.capture_turns,
+    promotion_threshold: config.promotion_threshold,
+  });
+  const entries = generator.generate({ session_id: sessionId, summary, signals });
+
+  if (entries.length === 0) {
+    experienceStore.recordEvaluation(sessionId, 0);
+    logger.log("skip", "pre_compact_phase2_no_entries", {
+      session_id: sessionId,
+      last_evaluated_at: lastEval,
+    });
+    return;
+  }
+
+  let embedder: EmbedderType | undefined;
+  let embedderReady = false;
+  try {
+    const { Embedder } = await import("../retrieval/embedder.js");
+    embedder = new Embedder();
+    await embedder.initialize();
+    embedderReady = true;
+  } catch (err) {
+    console.error(
+      `[ACM] pre-compact: Embedder initialization failed, storing entries without embedding: ` +
+        `${err instanceof Error ? err.message : String(err)}`
+    );
+    logger.log("error", "pre_compact_embedder_init_failed", {
+      session_id: sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  let persisted = 0;
+  try {
+    for (const entryData of entries) {
+      try {
+        let saved;
+        if (embedderReady && embedder) {
+          const text = buildEmbeddingText(entryData);
+          const embedding = await embedder.embed(text);
+          saved = experienceStore.createWithEmbedding(
+            { ...entryData, project: projectName },
+            embedding
+          );
+        } else {
+          saved = experienceStore.create({ ...entryData, project: projectName });
+        }
+        if (saved) persisted++;
+      } catch (entryErr) {
+        console.error(
+          `[ACM] pre-compact: failed to persist entry (type="${entryData.type}") ` +
+            `for session "${sessionId}": ` +
+            `${entryErr instanceof Error ? entryErr.message : String(entryErr)}`
+        );
+        logger.log("error", "pre_compact_entry_persist_failed", {
+          session_id: sessionId,
+          entry_type: entryData.type,
+          error: entryErr instanceof Error ? entryErr.message : String(entryErr),
+        });
+      }
+    }
+  } finally {
+    if (embedder) embedder.dispose();
+  }
+
+  if (persisted < entries.length) {
+    console.error(
+      `[ACM] pre-compact: ${entries.length - persisted} of ${entries.length} ` +
+        `experience entries failed to persist for session "${sessionId}"`
+    );
+  }
+
+  // Leaving the segment boundary un-advanced lets the next SessionEnd / PreCompact
+  // invocation re-process the same signals (idempotent recovery). Applies only when
+  // EVERY entry failed; partial success still advances, so individual failed entries
+  // are dropped rather than duplicated on retry.
+  if (persisted === 0 && entries.length > 0) {
+    logger.log("error", "pre_compact_all_entries_failed_no_boundary_advance", {
+      session_id: sessionId,
+      entries_attempted: entries.length,
+    });
+    return;
+  }
+
+  experienceStore.recordEvaluation(sessionId, persisted);
+  logger.log("generation", "pre_compact_experiences_created", {
+    session_id: sessionId,
+    generated: entries.length,
+    persisted,
+    types: entries.map((e) => e.type),
+    embedded: embedderReady,
+  });
+}
 
 export async function handlePreCompact(stdin: string): Promise<void> {
   const ctx = await bootstrapHook(stdin);
@@ -18,95 +256,9 @@ export async function handlePreCompact(stdin: string): Promise<void> {
 
   let sessionId: string | undefined;
   try {
-    const { input, config, signalStore } = ctx;
-    sessionId = requireInputString(input, "session_id", "PreCompact");
-
-    // Skip if corrective signals already exist for this session
-    if (signalStore.hasSignalOfType(sessionId, "corrective_instruction")) {
-      ctx.logger.log("skip", "pre_compact_skipped", {
-        session_id: sessionId,
-        reason: "corrective_signals_already_exist",
-      });
-      return;
-    }
-
-    const transcriptPath = input.transcript_path;
-    if (typeof transcriptPath !== "string" || !transcriptPath) {
-      ctx.logger.log("skip", "pre_compact_skipped", {
-        session_id: sessionId,
-        reason: "no_transcript_path",
-      });
-      return;
-    }
-
-    const parsed = parseTranscript(transcriptPath);
-    if (parsed.turns.length <= 1) {
-      ctx.logger.log("skip", "pre_compact_skipped", {
-        session_id: sessionId,
-        reason: "single_turn_transcript",
-      });
-      return;
-    }
-
-    let corrections;
-    try {
-      corrections = await classifyCorrections(parsed, {
-        ollamaUrl: config.ollama_url,
-        model: config.ollama_model,
-      });
-    } catch (err) {
-      console.error(
-        `[ACM] pre-compact: transcript classification failed for "${transcriptPath}": ` +
-          `${err instanceof Error ? err.message : String(err)}`
-      );
-      ctx.logger.log("error", "pre_compact_classification_failed", {
-        session_id: sessionId,
-        transcript_path: transcriptPath,
-        error: err instanceof Error ? err.message : String(err),
-        stack: err instanceof Error ? err.stack : undefined,
-      });
-      return;
-    }
-
-    const storedCorrections: typeof corrections = [];
-    for (const c of corrections) {
-      try {
-        signalStore.addSignal(sessionId, "corrective_instruction", {
-          prompt: c.message.text.slice(0, 200),
-          reason: c.reason,
-          confidence: c.confidence,
-          method: c.method,
-          source: "pre_compact",
-        });
-        storedCorrections.push(c);
-      } catch (storeErr) {
-        console.error(
-          `[ACM] pre-compact: failed to store corrective signal for session "${sessionId}": ` +
-            `${storeErr instanceof Error ? storeErr.message : String(storeErr)}`
-        );
-        ctx.logger.log("error", "pre_compact_signal_store_failed", {
-          session_id: sessionId,
-          error: storeErr instanceof Error ? storeErr.message : String(storeErr),
-        });
-      }
-    }
-
-    if (storedCorrections.length < corrections.length) {
-      console.error(
-        `[ACM] pre-compact: ${corrections.length - storedCorrections.length} of ${corrections.length} signal(s) failed to store for session "${sessionId}"`
-      );
-    }
-
-    if (storedCorrections.length > 0) {
-      ctx.logger.log("detection", "pre_compact_signals_preserved", {
-        session_id: sessionId,
-        corrective_count: storedCorrections.length,
-        methods: storedCorrections.map((c) => c.method),
-      });
-      console.error(
-        `[ACM] pre-compact: preserved ${storedCorrections.length} corrective signal(s) for session "${sessionId}"`
-      );
-    }
+    sessionId = requireInputString(ctx.input, "session_id", "PreCompact");
+    await runPhase1(ctx, sessionId);
+    await runPhase2(ctx, sessionId);
   } finally {
     try {
       ctx.cleanup();

--- a/src/hooks/pre-compact.ts
+++ b/src/hooks/pre-compact.ts
@@ -206,10 +206,29 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
         }
         if (saved) persisted++;
       } catch (entryErr) {
-        // Persistent embed failure (not just this entry) collapses the rest of
-        // the loop into embedding-less persist so we don't lose all remaining
-        // entries to the same broken model.
-        if (embedderReady) embedderReady = false;
+        // On embed failure: disable embedder for subsequent entries AND retry
+        // this entry with embedding-less persist so it isn't silently dropped.
+        if (embedderReady) {
+          embedderReady = false;
+          try {
+            const retrySaved = experienceStore.create({ ...entryData, project: projectName });
+            if (retrySaved) {
+              persisted++;
+              logger.log("skip", "pre_compact_entry_embedding_less_retry", {
+                session_id: sessionId,
+                entry_type: entryData.type,
+                initial_error: entryErr instanceof Error ? entryErr.message : String(entryErr),
+              });
+              continue;
+            }
+          } catch (retryErr) {
+            console.error(
+              `[ACM] pre-compact: embedding-less retry also failed for entry (type="${entryData.type}") ` +
+                `in session "${sessionId}": ` +
+                `${retryErr instanceof Error ? retryErr.message : String(retryErr)}`
+            );
+          }
+        }
         console.error(
           `[ACM] pre-compact: failed to persist entry (type="${entryData.type}") ` +
             `for session "${sessionId}": ` +
@@ -245,7 +264,20 @@ async function runPhase2(ctx: HookContext, sessionId: string): Promise<void> {
     return;
   }
 
-  experienceStore.recordEvaluation(sessionId, persisted);
+  try {
+    experienceStore.recordEvaluation(sessionId, persisted);
+  } catch (err) {
+    console.error(
+      `[ACM] pre-compact: boundary advance failed for session "${sessionId}", ` +
+        `${persisted} entries may duplicate on next invocation: ` +
+        `${err instanceof Error ? err.message : String(err)}`
+    );
+    logger.log("error", "pre_compact_record_evaluation_failed", {
+      session_id: sessionId,
+      persisted,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
   logger.log("generation", "pre_compact_experiences_created", {
     session_id: sessionId,
     generated: entries.length,

--- a/tests/hooks/pre-compact.test.ts
+++ b/tests/hooks/pre-compact.test.ts
@@ -2,7 +2,8 @@
  * Tests for PreCompact hook — corrective signal preservation (Issue #90)
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { handlePreCompact } from "../../src/hooks/pre-compact.js";
 import { initializeDatabase } from "../../src/store/schema.js";
 import { SessionSignalStore } from "../../src/signals/session-store.js";
@@ -424,6 +425,64 @@ describe("PreCompact hook", () => {
         const expStore = new ExperienceStore(db, DEFAULT_CONFIG);
         const entries = expStore.list().filter((e) => e.session_id === "pre-compact-record-fail");
         expect(entries.length).toBeGreaterThan(0);
+      } finally {
+        db.close();
+      }
+    }
+  );
+
+  it(
+    "records evaluation boundary even when generator yields no entries (#134)",
+    { timeout: 15000 },
+    async () => {
+      const dbPath = setupEnv(TMP_DIR);
+      // High promotion_threshold forces ExperienceGenerator to yield []
+      // despite having signals — tests the entries.length===0 boundary advance.
+      process.env.ACM_CONFIG_PATH = join(TMP_DIR, "high-threshold-config.json");
+      writeFileSync(
+        process.env.ACM_CONFIG_PATH,
+        JSON.stringify({
+          db_path: dbPath,
+          promotion_threshold: 0.99,
+          mode: "full",
+          top_k: 5,
+          capture_turns: 5,
+          verbosity: "normal",
+          max_experiences_per_project: 500,
+          recency_half_life_days: 30,
+          inject_corrective_bodies_score_threshold: 0.6,
+          inject_corrective_bodies_max: 3,
+        })
+      );
+
+      const db0 = await initializeDatabase(dbPath);
+      try {
+        const store = new SessionSignalStore(db0);
+        store.addSignal("pre-compact-zero-entries", "corrective_instruction", {
+          prompt: "single weak signal",
+          reason: "test",
+          confidence: 0.1,
+          method: "llm",
+          source: "pre_compact",
+        });
+      } finally {
+        db0.close();
+      }
+
+      const transcriptPath = writeTranscript(TMP_DIR, [userLine("x"), assistantLine("ok")]);
+      const stdin = JSON.stringify({
+        session_id: "pre-compact-zero-entries",
+        transcript_path: transcriptPath,
+        cwd: TMP_DIR,
+      });
+
+      await handlePreCompact(stdin);
+
+      const db = await initializeDatabase(dbPath);
+      try {
+        const expStore = new ExperienceStore(db, DEFAULT_CONFIG);
+        // Boundary DID advance (no entries generated, but evaluation recorded)
+        expect(expStore.getLastEvaluatedAt("pre-compact-zero-entries")).toBeTruthy();
       } finally {
         db.close();
       }

--- a/tests/hooks/pre-compact.test.ts
+++ b/tests/hooks/pre-compact.test.ts
@@ -377,6 +377,59 @@ describe("PreCompact hook", () => {
     }
   );
 
+  it(
+    "handles recordEvaluation throwing without crashing the hook (#134)",
+    { timeout: 15000 },
+    async () => {
+      const dbPath = setupEnv(TMP_DIR);
+      const db0 = await initializeDatabase(dbPath);
+      try {
+        const store = new SessionSignalStore(db0);
+        for (let i = 0; i < 3; i++) {
+          store.addSignal("pre-compact-record-fail", "corrective_instruction", {
+            prompt: `corrective body ${i}`,
+            reason: "test",
+            confidence: 0.9,
+            method: "llm",
+            source: "pre_compact",
+          });
+        }
+      } finally {
+        db0.close();
+      }
+
+      const storeMod = await import("../../src/store/experience-store.js");
+      const recordSpy = vi
+        .spyOn(storeMod.ExperienceStore.prototype, "recordEvaluation")
+        .mockImplementation(() => {
+          throw new Error("simulated recordEvaluation failure");
+        });
+
+      const transcriptPath = writeTranscript(TMP_DIR, [userLine("x"), assistantLine("ok")]);
+      const stdin = JSON.stringify({
+        session_id: "pre-compact-record-fail",
+        transcript_path: transcriptPath,
+        cwd: TMP_DIR,
+      });
+
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      // Should not throw — the hook catches the recordEvaluation error and logs it
+      await expect(handlePreCompact(stdin)).resolves.toBeUndefined();
+      errSpy.mockRestore();
+      recordSpy.mockRestore();
+
+      // Entries were persisted (spy only mocked recordEvaluation)
+      const db = await initializeDatabase(dbPath);
+      try {
+        const expStore = new ExperienceStore(db, DEFAULT_CONFIG);
+        const entries = expStore.list().filter((e) => e.session_id === "pre-compact-record-fail");
+        expect(entries.length).toBeGreaterThan(0);
+      } finally {
+        db.close();
+      }
+    }
+  );
+
   it("continues gracefully when transcript analysis fails", async () => {
     setupEnv(TMP_DIR);
     const transcriptPath = writeTranscript(TMP_DIR, [

--- a/tests/hooks/pre-compact.test.ts
+++ b/tests/hooks/pre-compact.test.ts
@@ -325,6 +325,58 @@ describe("PreCompact hook", () => {
     }
   );
 
+  it(
+    "falls back to embedding-less persist when embedder throws mid-loop (#134)",
+    { timeout: 20000 },
+    async () => {
+      const dbPath = setupEnv(TMP_DIR);
+      const db0 = await initializeDatabase(dbPath);
+      try {
+        const store = new SessionSignalStore(db0);
+        for (let i = 0; i < 3; i++) {
+          store.addSignal("pre-compact-embed-fail", "corrective_instruction", {
+            prompt: `corrective body ${i}`,
+            reason: "test",
+            confidence: 0.9,
+            method: "llm",
+            source: "pre_compact",
+          });
+        }
+      } finally {
+        db0.close();
+      }
+
+      const embedderMod = await import("../../src/retrieval/embedder.js");
+      const embedSpy = vi
+        .spyOn(embedderMod.Embedder.prototype, "embed")
+        .mockRejectedValue(new Error("simulated embed failure"));
+
+      const transcriptPath = writeTranscript(TMP_DIR, [userLine("x"), assistantLine("ok")]);
+      const stdin = JSON.stringify({
+        session_id: "pre-compact-embed-fail",
+        transcript_path: transcriptPath,
+        cwd: TMP_DIR,
+      });
+
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      await handlePreCompact(stdin);
+      errSpy.mockRestore();
+      embedSpy.mockRestore();
+
+      const db = await initializeDatabase(dbPath);
+      try {
+        const expStore = new ExperienceStore(db, DEFAULT_CONFIG);
+        const entries = expStore.list().filter((e) => e.session_id === "pre-compact-embed-fail");
+        // embed failed on first entry → embedderReady toggled off → remaining
+        // entries persist without embedding, so boundary advances.
+        expect(entries.length).toBeGreaterThan(0);
+        expect(expStore.getLastEvaluatedAt("pre-compact-embed-fail")).toBeTruthy();
+      } finally {
+        db.close();
+      }
+    }
+  );
+
   it("continues gracefully when transcript analysis fails", async () => {
     setupEnv(TMP_DIR);
     const transcriptPath = writeTranscript(TMP_DIR, [

--- a/tests/hooks/pre-compact.test.ts
+++ b/tests/hooks/pre-compact.test.ts
@@ -6,6 +6,8 @@ import { mkdirSync, rmSync } from "node:fs";
 import { handlePreCompact } from "../../src/hooks/pre-compact.js";
 import { initializeDatabase } from "../../src/store/schema.js";
 import { SessionSignalStore } from "../../src/signals/session-store.js";
+import { ExperienceStore } from "../../src/store/experience-store.js";
+import { DEFAULT_CONFIG } from "../../src/store/types.js";
 import {
   userLine,
   interruptLine,
@@ -137,6 +139,191 @@ describe("PreCompact hook", () => {
       db.close();
     }
   });
+
+  it(
+    "generates experience entry with corrective_bodies at PreCompact (#134)",
+    { timeout: 20000 },
+    async () => {
+      const dbPath = setupEnv(TMP_DIR);
+      const transcriptPath = writeTranscript(TMP_DIR, [
+        userLine("Implement feature X"),
+        assistantLine("Working on it..."),
+        interruptLine(),
+        userLine("No, that's wrong. Use a different approach please"),
+        assistantLine("OK, using a different approach"),
+        userLine("Still wrong. Use TypeScript generics for the signature."),
+        assistantLine("Understood, applying generics."),
+        userLine("Actually, rewrite the whole function from scratch."),
+        assistantLine("Rewriting."),
+      ]);
+
+      const stdin = JSON.stringify({
+        session_id: "pre-compact-entry-s1",
+        transcript_path: transcriptPath,
+        cwd: TMP_DIR,
+      });
+
+      await handlePreCompact(stdin);
+
+      const db = await initializeDatabase(dbPath);
+      try {
+        const expStore = new ExperienceStore(db, DEFAULT_CONFIG);
+        const entries = expStore.list().filter((e) => e.session_id === "pre-compact-entry-s1");
+        expect(entries.length).toBeGreaterThan(0);
+        const failure = entries.find((e) => e.type === "failure");
+        expect(failure).toBeDefined();
+        expect(failure!.corrective_bodies).toBeDefined();
+        expect(failure!.corrective_bodies!.length).toBeGreaterThan(0);
+        expect(expStore.getLastEvaluatedAt("pre-compact-entry-s1")).toBeTruthy();
+      } finally {
+        db.close();
+      }
+    }
+  );
+
+  it(
+    "advances segment boundary so subsequent PreCompact does not duplicate entries (#134)",
+    { timeout: 20000 },
+    async () => {
+      const dbPath = setupEnv(TMP_DIR);
+      const transcriptPath = writeTranscript(TMP_DIR, [
+        userLine("Do X"),
+        assistantLine("ok"),
+        interruptLine(),
+        userLine("No that's wrong, do Y instead"),
+        assistantLine("ok Y"),
+        userLine("Still wrong, do Z"),
+        assistantLine("ok Z"),
+      ]);
+
+      const stdin = JSON.stringify({
+        session_id: "pre-compact-entry-s2",
+        transcript_path: transcriptPath,
+        cwd: TMP_DIR,
+      });
+
+      await handlePreCompact(stdin);
+      await handlePreCompact(stdin);
+
+      const db = await initializeDatabase(dbPath);
+      try {
+        const expStore = new ExperienceStore(db, DEFAULT_CONFIG);
+        const entries = expStore.list().filter((e) => e.session_id === "pre-compact-entry-s2");
+        const failures = entries.filter((e) => e.type === "failure");
+        expect(failures.length).toBe(1);
+      } finally {
+        db.close();
+      }
+    }
+  );
+
+  it(
+    "Phase 2 runs independently when Phase 1 is skipped due to pre-existing signals (#134)",
+    { timeout: 15000 },
+    async () => {
+      const dbPath = setupEnv(TMP_DIR);
+      const db0 = await initializeDatabase(dbPath);
+      try {
+        const store = new SessionSignalStore(db0);
+        for (let i = 0; i < 3; i++) {
+          store.addSignal("pre-compact-phase2-only", "corrective_instruction", {
+            prompt: `preseeded corrective ${i}`,
+            reason: "test",
+            confidence: 0.9,
+            method: "llm",
+            source: "pre_compact",
+          });
+        }
+      } finally {
+        db0.close();
+      }
+
+      const transcriptPath = writeTranscript(TMP_DIR, [
+        userLine("Stub"),
+        assistantLine("ok"),
+        userLine("Stop"),
+      ]);
+      const stdin = JSON.stringify({
+        session_id: "pre-compact-phase2-only",
+        transcript_path: transcriptPath,
+        cwd: TMP_DIR,
+      });
+
+      await handlePreCompact(stdin);
+
+      const db = await initializeDatabase(dbPath);
+      try {
+        const expStore = new ExperienceStore(db, DEFAULT_CONFIG);
+        const entries = expStore.list().filter((e) => e.session_id === "pre-compact-phase2-only");
+        const failure = entries.find((e) => e.type === "failure");
+        expect(failure).toBeDefined();
+        expect(failure!.corrective_bodies?.length ?? 0).toBeGreaterThan(0);
+        expect(expStore.getLastEvaluatedAt("pre-compact-phase2-only")).toBeTruthy();
+      } finally {
+        db.close();
+      }
+    }
+  );
+
+  it(
+    "does not advance boundary when every entry fails to persist (#134)",
+    { timeout: 15000 },
+    async () => {
+      const dbPath = setupEnv(TMP_DIR);
+      const db0 = await initializeDatabase(dbPath);
+      try {
+        const store = new SessionSignalStore(db0);
+        for (let i = 0; i < 3; i++) {
+          store.addSignal("pre-compact-persist-fail", "corrective_instruction", {
+            prompt: `fail-test corrective ${i}`,
+            reason: "test",
+            confidence: 0.9,
+            method: "llm",
+            source: "pre_compact",
+          });
+        }
+      } finally {
+        db0.close();
+      }
+
+      const storeMod = await import("../../src/store/experience-store.js");
+      const createSpy = vi
+        .spyOn(storeMod.ExperienceStore.prototype, "createWithEmbedding")
+        .mockImplementation(() => {
+          throw new Error("simulated persist failure");
+        });
+      const createPlainSpy = vi
+        .spyOn(storeMod.ExperienceStore.prototype, "create")
+        .mockImplementation(() => {
+          throw new Error("simulated persist failure");
+        });
+
+      const transcriptPath = writeTranscript(TMP_DIR, [
+        userLine("Stub"),
+        assistantLine("ok"),
+        userLine("Stop"),
+      ]);
+      const stdin = JSON.stringify({
+        session_id: "pre-compact-persist-fail",
+        transcript_path: transcriptPath,
+        cwd: TMP_DIR,
+      });
+
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      await handlePreCompact(stdin);
+      errSpy.mockRestore();
+      createSpy.mockRestore();
+      createPlainSpy.mockRestore();
+
+      const db = await initializeDatabase(dbPath);
+      try {
+        const expStore = new ExperienceStore(db, DEFAULT_CONFIG);
+        expect(expStore.getLastEvaluatedAt("pre-compact-persist-fail")).toBeNull();
+      } finally {
+        db.close();
+      }
+    }
+  );
 
   it("continues gracefully when transcript analysis fails", async () => {
     setupEnv(TMP_DIR);


### PR DESCRIPTION
## Summary

Closes #134. Follow-up race tracked separately: #135.

Long-running sessions rarely fire SessionEnd, so corrective signals preserved by PreCompact (#119) accumulated without ever becoming experience entries — observed 24 correctives stuck in one session for 2 days with zero failure entries generated. PreCompact now runs Phase 2 (entry generation) alongside the existing Phase 1 (signal preservation), reusing the session_evaluations segment boundary (#115) so SessionEnd does not re-process the same signals.

- `src/hooks/pre-compact.ts`: split into `runPhase1` / `runPhase2`, guard Phase 1 storage reads, always try Phase 2 regardless of Phase 1 outcome, skip signals DB fetch when there are no new signals, toggle `embedderReady=false` on per-entry embed failure
- `tests/hooks/pre-compact.test.ts`: 4 new cases — entry generation + `corrective_bodies` populated, boundary non-duplication, Phase 2 independent when Phase 1 skipped, persist-all-fail leaves boundary
- `docs/SPECIFICATION.md` Section 3.7: document Phase 1/2 split and rationale

## Test plan

- [x] `npx vitest run` — 682 tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] 実機: `sqlite3 ~/.acm/experiences.db` で compact 後に新 failure entry が `corrective_bodies IS NOT NULL` で現れることを確認
- [ ] 実機: `/acm:report` に新 entry が surface することを確認

## Process notes

This PR is a redo of the previously closed PR #136. The first attempt shipped the correct code but bypassed the autopilot phase-skill invocations (Skill tool) and instead performed equivalent work inline. Re-running the full autopilot pipeline with proper Skill tool invocations (sprint → audit → simplify → ship) this time. See claude-tools #253 for the root-cause analysis on token-economy bias and the proposed runtime verification hook.

## Non-goals

- session_evaluations race atomization (#135)
- Shared pipeline extraction between pre-compact and session-end (deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)